### PR TITLE
Feature/431979 fix azure functions version - AB#431979

### DIFF
--- a/src/EPR.ProducerContentValidation.FunctionApp/EPR.ProducerContentValidation.FunctionApp.csproj
+++ b/src/EPR.ProducerContentValidation.FunctionApp/EPR.ProducerContentValidation.FunctionApp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <AzureFunctionsVersion>V4</AzureFunctionsVersion>
+        <AzureFunctionsVersion>v4</AzureFunctionsVersion>
         <SonarQubeTestProject>false</SonarQubeTestProject>
         <!-- SonarCloud does not recognise file-scoped namespaces in current version. -->
         <NoWarn>S3903</NoWarn>

--- a/src/EPR.ProducerContentValidation.FunctionApp/EPR.ProducerContentValidation.FunctionApp.csproj
+++ b/src/EPR.ProducerContentValidation.FunctionApp/EPR.ProducerContentValidation.FunctionApp.csproj
@@ -2,8 +2,6 @@
     <PropertyGroup>
         <AzureFunctionsVersion>v4</AzureFunctionsVersion>
         <SonarQubeTestProject>false</SonarQubeTestProject>
-        <!-- SonarCloud does not recognise file-scoped namespaces in current version. -->
-        <NoWarn>S3903</NoWarn>
         <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
The version in the function app .csproj file was set to

`<AzureFunctionsVersion>V4</AzureFunctionsVersion>`

When developers run this on their own machines, the functions wouldn't start. The version should have a lowercase v:

`<AzureFunctionsVersion>v4</AzureFunctionsVersion>`

An obsolete SonarQube warning was also removed because the current version already supports file-scoped namespaces