### PR TITLE
Feature/447183 epr pom func producer validation sonar qube cleanup 

### DIFF
--- a/src/EPR.ProducerContentValidation.Application.UnitTests/EPR.ProducerContentValidation.Application.UnitTests.csproj
+++ b/src/EPR.ProducerContentValidation.Application.UnitTests/EPR.ProducerContentValidation.Application.UnitTests.csproj
@@ -4,6 +4,7 @@
         <IsPackable>false</IsPackable>
         <SonarQubeTestProject>true</SonarQubeTestProject>
         <TargetFramework>net8.0</TargetFramework>
+		<NoWarn>CA1859</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/EPR.ProducerContentValidation.Application.UnitTests/Services/SubmissionApiClientTests.cs
+++ b/src/EPR.ProducerContentValidation.Application.UnitTests/Services/SubmissionApiClientTests.cs
@@ -82,6 +82,7 @@ public class SubmissionApiClientTests
                 StatusCode = httpStatusCode
             })
             .Verifiable();
+
         var httpClient = new HttpClient(handlerMock.Object)
         {
             BaseAddress = new Uri("http://localhost:5087/")

--- a/src/EPR.ProducerContentValidation.Application/ConfigureServices.cs
+++ b/src/EPR.ProducerContentValidation.Application/ConfigureServices.cs
@@ -55,15 +55,8 @@ public static class ConfigureServices
     private static void ConfigureSection<TOptions>(this IServiceCollection services, string sectionKey, bool validate = true)
         where TOptions : class, new()
     {
-        if (services == null)
-        {
-            throw new ArgumentNullException(nameof(services));
-        }
-
-        if (sectionKey == null)
-        {
-            throw new ArgumentNullException(nameof(sectionKey));
-        }
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(sectionKey);
 
         services.AddOptions<TOptions>().Configure(delegate(TOptions options, IConfiguration config)
         {

--- a/src/EPR.ProducerContentValidation.Application/ConfigureServices.cs
+++ b/src/EPR.ProducerContentValidation.Application/ConfigureServices.cs
@@ -55,8 +55,15 @@ public static class ConfigureServices
     private static void ConfigureSection<TOptions>(this IServiceCollection services, string sectionKey, bool validate = true)
         where TOptions : class, new()
     {
-        ArgumentNullException.ThrowIfNull(services, nameof(services));
-        ArgumentNullException.ThrowIfNull(sectionKey, nameof(sectionKey));
+        if (services == null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        if (sectionKey == null)
+        {
+            throw new ArgumentNullException(nameof(sectionKey));
+        }
 
         services.AddOptions<TOptions>().Configure(delegate(TOptions options, IConfiguration config)
         {

--- a/src/EPR.ProducerContentValidation.Application/ConfigureServices.cs
+++ b/src/EPR.ProducerContentValidation.Application/ConfigureServices.cs
@@ -55,15 +55,8 @@ public static class ConfigureServices
     private static void ConfigureSection<TOptions>(this IServiceCollection services, string sectionKey, bool validate = true)
         where TOptions : class, new()
     {
-        if (services == null)
-        {
-            throw new ArgumentNullException(nameof(services));
-        }
-
-        if (sectionKey == null)
-        {
-            throw new ArgumentNullException(nameof(sectionKey));
-        }
+        ArgumentNullException.ThrowIfNull(services, nameof(services));
+        ArgumentNullException.ThrowIfNull(sectionKey, nameof(sectionKey));
 
         services.AddOptions<TOptions>().Configure(delegate(TOptions options, IConfiguration config)
         {

--- a/src/EPR.ProducerContentValidation.Application/EPR.ProducerContentValidation.Application.csproj
+++ b/src/EPR.ProducerContentValidation.Application/EPR.ProducerContentValidation.Application.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <SonarQubeTestProject>false</SonarQubeTestProject>
         <TargetFramework>net8.0</TargetFramework>
+		<NoWarn>S107;CA1859</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/EPR.ProducerContentValidation.Application/Validators/PropertyValidators/WarningValidators/DrinksContainerQuantityUnitWeightValidator.cs
+++ b/src/EPR.ProducerContentValidation.Application/Validators/PropertyValidators/WarningValidators/DrinksContainerQuantityUnitWeightValidator.cs
@@ -29,9 +29,9 @@ public class DrinksContainerQuantityUnitWeightValidator : AbstractValidator<Prod
 
     protected override bool PreValidate(ValidationContext<ProducerRow> context, ValidationResult result)
     {
-        if (context.RootContextData.ContainsKey(ErrorCode.ValidationContextErrorKey))
+        if (context.RootContextData.TryGetValue(ErrorCode.ValidationContextErrorKey, out var value))
         {
-            var errors = context.RootContextData[ErrorCode.ValidationContextErrorKey] as List<string>;
+            var errors = value as List<string>;
             if (errors != null && errors.Exists(code => _skipRuleErrorCodes.Contains(code)))
             {
                 return false;

--- a/src/EPR.ProducerContentValidation.Application/Validators/PropertyValidators/WarningValidators/QuantityKgValidator.cs
+++ b/src/EPR.ProducerContentValidation.Application/Validators/PropertyValidators/WarningValidators/QuantityKgValidator.cs
@@ -22,9 +22,9 @@ public class QuantityKgValidator : AbstractValidator<ProducerRow>
 
     protected override bool PreValidate(ValidationContext<ProducerRow> context, ValidationResult result)
     {
-        if (context.RootContextData.ContainsKey(ErrorCode.ValidationContextErrorKey))
+        if (context.RootContextData.TryGetValue(ErrorCode.ValidationContextErrorKey, out var value))
         {
-            var errors = context.RootContextData[ErrorCode.ValidationContextErrorKey] as List<string>;
+            var errors = value as List<string>;
             return !errors?.Exists(code => _skipRuleErrorCodes.Contains(code)) ?? true;
         }
 

--- a/src/EPR.ProducerContentValidation.FunctionApp/Dockerfile
+++ b/src/EPR.ProducerContentValidation.FunctionApp/Dockerfile
@@ -28,4 +28,4 @@ USER dotnet
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 
-COPY --from=installer-env --chown=dotnet ["/home/site/wwwroot", "/home/site/wwwroot"]
+COPY --from=installer-env ["/home/site/wwwroot", "/home/site/wwwroot"]


### PR DESCRIPTION
Changes related to SonarQube issues and security hotspots. 

Details of change: 

1. Having executables not owned by root is security-sensitivedocker:S6504
2. Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method(external_roslyn:CA1854)
3. Use ArgumentNullException throw helper(external_roslyn:CA1510)
4. Add <nowarn> for issue: S107	- Methods should not have too many parameterscsharpsquid:S107 - for Constructor has 8 parameters, which is greater than the 7 authorized.
5. Add <nowarn> for issue: CA1859 - Use concrete types when possible for improved performance(external_roslyn:CA1859) - for Change type of field '_systemUnderTest' from 'EPR.ProducerContentValidation.Application.Validators.Factories.Interfaces.IProducerRowWarningValidatorFactory' to 'EPR.ProducerContentValidation.Application.Validators.Factories.ProducerRowWarningValidatorFactory' for improved performance

