### PR TITLE
#450396 - Fix for reused fluent validation context showing duplicate …

### DIFF
--- a/src/EPR.ProducerContentValidation.Application/Validators/CompositeValidator.cs
+++ b/src/EPR.ProducerContentValidation.Application/Validators/CompositeValidator.cs
@@ -53,17 +53,13 @@ public class CompositeValidator : ICompositeValidator
             errorContext.RootContextData.Add(SubmissionPeriodOption.Section, submissionOptions.Value);
             warningContext.RootContextData.Add(SubmissionPeriodOption.Section, submissionOptions.Value);
 
-            // Validate any errors
             await ValidateIssue(row, errors, blobName, IssueType.Error, errorContext);
 
-            // Cannot re-use the same context. Internally FluentValidation uses the existing context error collection:  var result = new ValidationResult(context.Failures);
-            // So, for warnings use a seperate context, but copy the rootcontexterrorkey data into the new context (the warning validation classes use these in the PreValidate method)
-            if (errorContext.RootContextData.ContainsKey(ErrorCode.ValidationContextErrorKey))
+            if (errorContext.RootContextData.TryGetValue(ErrorCode.ValidationContextErrorKey, out var validationContextErrorKey))
             {
-                warningContext.RootContextData[ErrorCode.ValidationContextErrorKey] = errorContext.RootContextData[ErrorCode.ValidationContextErrorKey];
+                warningContext.RootContextData[ErrorCode.ValidationContextErrorKey] = validationContextErrorKey;
             }
 
-            // Validate any warnings
             await ValidateIssue(row, warnings, blobName, IssueType.Warning, warningContext);
         }
     }


### PR DESCRIPTION
From the ticket (https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_boards/board/t/EPR%20Production%20Issues/Stories?workitem=450396): When a producer tries to submit data, sometimes they receive exactly the same message as an error and subsequently the same as a warning for the same entry.

Except, replace the word sometimes with always.

Issue is caused by the re-use of the FluentValidation context. When ValidateAsync is called, internall FluentValidation creates a new ValidationResult built on errors already associated with the context. Therefore, the change calls for a separate context to be used for warnings. For further info, see line 224 of the FluentValidation AbstractValidator class: https://github.com/FluentValidation/FluentValidation/blob/main/src/FluentValidation/AbstractValidator.cs