### PR TITLE
Add CLR to the list of excluded packaging types when validating the total packaging material weight

### DIFF
--- a/src/EPR.ProducerContentValidation.Application.UnitTests/Validators/GroupedValidators/WarningValidators/TotalPackagingMaterialValidatorTests.cs
+++ b/src/EPR.ProducerContentValidation.Application.UnitTests/Validators/GroupedValidators/WarningValidators/TotalPackagingMaterialValidatorTests.cs
@@ -46,6 +46,28 @@ public class TotalPackagingMaterialValidatorTests
         warnings.Should().HaveCount(1).And.Subject.First().ErrorCodes.Should().HaveCount(1).And.Contain(ErrorCode.WarningPackagingMaterialWeightLessThanLimitKg);
     }
 
+    [DataTestMethod]
+    [DataRow(PackagingType.SelfManagedConsumerWaste)]
+    [DataRow(PackagingType.SelfManagedOrganisationWaste)]
+    [DataRow(PackagingType.SmallOrganisationPackagingAll)]
+    [DataRow(PackagingType.ClosedLoopRecycling)]
+    public async Task ValidateAndAddWarning_RejectsRow_WhenTotalWeightIsLessThan25000Kg_And_AdditionalRowsContainExcludedPackagingTypes_TakingTheTotalAbove_25000Kg(string excludedPackagingType)
+    {
+        // Arrange
+        var errors = new List<ProducerValidationEventIssueRequest>();
+        var warnings = new List<ProducerValidationEventIssueRequest>();
+        var producer = BuildProducer();
+
+        producer.Rows.Add(BuildProducerRow(quantityKg: "24000"));
+        producer.Rows.Add(BuildProducerRow(quantityKg: "10000", packagingType: excludedPackagingType));
+
+        // Act
+        await _systemUnderTest.ValidateAsync(producer.Rows, StoreKey, producer.BlobName, errors, warnings);
+
+        // Assert
+        warnings.Should().HaveCount(1).And.Subject.First().ErrorCodes.Should().HaveCount(1).And.Contain(ErrorCode.WarningPackagingMaterialWeightLessThanLimitKg);
+    }
+
     [TestMethod]
     public async Task ValidateAsync_AcceptsRow_IfQuantityWeightIsValid()
     {

--- a/src/EPR.ProducerContentValidation.Application/Validators/GroupedValidators/WarningValidators/TotalPackagingMaterialValidator.cs
+++ b/src/EPR.ProducerContentValidation.Application/Validators/GroupedValidators/WarningValidators/TotalPackagingMaterialValidator.cs
@@ -19,7 +19,8 @@ public class TotalPackagingMaterialValidator : AbstractGroupedValidator
     {
         PackagingType.SelfManagedConsumerWaste,
         PackagingType.SelfManagedOrganisationWaste,
-        PackagingType.SmallOrganisationPackagingAll
+        PackagingType.SmallOrganisationPackagingAll,
+        PackagingType.ClosedLoopRecycling
     };
 
     public TotalPackagingMaterialValidator(IIssueCountService issueCountService)


### PR DESCRIPTION
Add CLR to the list of excluded packaging types when validating the total packaging material weight. Added a new test to verify all excluded packaging types.