### PR TITLE
SUB-235: Warn if CLR weight greater than overall weight of associated packaging material

### DIFF
--- a/src/EPR.ProducerContentValidation.Application.UnitTests/Validators/GroupedValidators/WarningValidators/ClrPackagingMaterialWeightGroupedValidatorTests.cs
+++ b/src/EPR.ProducerContentValidation.Application.UnitTests/Validators/GroupedValidators/WarningValidators/ClrPackagingMaterialWeightGroupedValidatorTests.cs
@@ -1,0 +1,240 @@
+﻿using EPR.ProducerContentValidation.Application.Constants;
+using EPR.ProducerContentValidation.Application.DTOs.SubmissionApi;
+using EPR.ProducerContentValidation.Application.Models;
+using EPR.ProducerContentValidation.Application.Services.Interfaces;
+using EPR.ProducerContentValidation.Application.Validators.GroupedValidators.WarningValidators;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace EPR.ProducerContentValidation.Application.UnitTests.Validators.GroupedValidators.WarningValidators;
+
+[TestClass]
+public class ClrPackagingMaterialWeightGroupedValidatorTests
+{
+    private const string StoreKey = "storeKey";
+    private readonly ClrPackagingMaterialWeightGroupedValidator _systemUnderTest;
+    private readonly Mock<IIssueCountService> _errorCountServiceMock;
+    private int _rowNumber = 1;
+
+    public ClrPackagingMaterialWeightGroupedValidatorTests()
+    {
+        _errorCountServiceMock = new Mock<IIssueCountService>();
+        _systemUnderTest = new ClrPackagingMaterialWeightGroupedValidator(_errorCountServiceMock.Object);
+    }
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        _errorCountServiceMock.Setup(x => x.GetRemainingIssueCapacityAsync(It.IsAny<string>())).ReturnsAsync(10);
+    }
+
+    [TestMethod]
+    public async Task ValidateAndAddWarning_ForDirectProducer_RejectsRow_WhenTotalClrWeightIsGreaterThanSameOverallMaterialTypeWeight()
+    {
+        // Arrange
+        var errors = new List<ProducerValidationEventIssueRequest>();
+        var warnings = new List<ProducerValidationEventIssueRequest>();
+        var producerId = Guid.NewGuid().ToString();
+        var producer = BuildProducer(producerId);
+
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.Household, materialType: MaterialType.Plastic, quantityKg: "10000"));
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.ClosedLoopRecycling, materialType: MaterialType.Plastic, quantityKg: "25000"));
+
+        // Act
+        await _systemUnderTest.ValidateAsync(producer.Rows, StoreKey, producer.BlobName, errors, warnings);
+
+        // Assert
+        warnings.Should().HaveCount(1).And.Subject.First().ErrorCodes.Should().HaveCount(1).And.Contain(ErrorCode.WarningClosedLoopPackagingWeightGreaterThanWeightOfThatPackagingMaterialOverall);
+    }
+
+    [TestMethod]
+    public async Task ValidateAndAddWarning_ForCSO_ForProducerAndSubsidiaries_RejectsRow_WhenTotalClrWeightIsGreaterThanSameOverallMaterialTypeWeight()
+    {
+        // Arrange
+        var errors = new List<ProducerValidationEventIssueRequest>();
+        var warnings = new List<ProducerValidationEventIssueRequest>();
+        var producerId = Guid.NewGuid().ToString();
+        var producer = BuildProducer(producerId);
+
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.Household, materialType: MaterialType.Plastic, quantityKg: "10000"));
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, subsidiaryId: Guid.NewGuid().ToString(), packagingType: PackagingType.Household, materialType: MaterialType.Plastic, quantityKg: "5000"));
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.ClosedLoopRecycling, materialType: MaterialType.Plastic, quantityKg: "10000"));
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, subsidiaryId: Guid.NewGuid().ToString(), packagingType: PackagingType.ClosedLoopRecycling, materialType: MaterialType.Plastic, quantityKg: "15000"));
+
+        // Act
+        await _systemUnderTest.ValidateAsync(producer.Rows, StoreKey, producer.BlobName, errors, warnings);
+
+        // Assert
+        warnings.Should().HaveCount(1).And.Subject.First().ErrorCodes.Should().HaveCount(1).And.Contain(ErrorCode.WarningClosedLoopPackagingWeightGreaterThanWeightOfThatPackagingMaterialOverall);
+    }
+
+    [TestMethod]
+    public async Task ValidateAndAddWarning_ForDirectProducer_RejectsIndividualMaterialTypes_WhenTotalClrWeightIsGreaterThanSameOverallMaterialTypeWeight()
+    {
+        // Arrange
+        var errors = new List<ProducerValidationEventIssueRequest>();
+        var warnings = new List<ProducerValidationEventIssueRequest>();
+        var producerId = Guid.NewGuid().ToString();
+        var producer = BuildProducer(producerId);
+
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.Household, materialType: MaterialType.Plastic, quantityKg: "10000"));
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.ClosedLoopRecycling, materialType: MaterialType.Plastic, quantityKg: "25000"));
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.Household, materialType: MaterialType.Glass, quantityKg: "10000"));
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.ClosedLoopRecycling, materialType: MaterialType.Glass, quantityKg: "10000"));
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.Household, materialType: MaterialType.Wood, quantityKg: "10000"));
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.ClosedLoopRecycling, materialType: MaterialType.Wood, quantityKg: "25000"));
+
+        // Act
+        await _systemUnderTest.ValidateAsync(producer.Rows, StoreKey, producer.BlobName, errors, warnings);
+
+        // Assert
+        warnings.Should().HaveCount(2).And.Subject.First().ErrorCodes.Should().HaveCount(1).And.Contain(ErrorCode.WarningClosedLoopPackagingWeightGreaterThanWeightOfThatPackagingMaterialOverall);
+    }
+
+    [TestMethod]
+    public async Task ValidateAndAddWarning_ForDirectProducer_AcceptsRow_WhenTotalClrWeightIsLessThanSameOverallMaterialTypeWeight()
+    {
+        // Arrange
+        var errors = new List<ProducerValidationEventIssueRequest>();
+        var warnings = new List<ProducerValidationEventIssueRequest>();
+        var producerId = Guid.NewGuid().ToString();
+        var producer = BuildProducer(producerId);
+
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.Household, materialType: MaterialType.Plastic, quantityKg: "10000"));
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.ClosedLoopRecycling, materialType: MaterialType.Plastic, quantityKg: "5000"));
+
+        // Act
+        await _systemUnderTest.ValidateAsync(producer.Rows, StoreKey, producer.BlobName, errors, warnings);
+
+        // Assert
+        warnings.Should().HaveCount(0);
+    }
+
+    [TestMethod]
+    public async Task ValidateAndAddWarning_ForCSO_ForProducerAndSubsidiaries_AcceptsRow_WhenTotalClrWeightIsLessThanSameOverallMaterialTypeWeight()
+    {
+        // Arrange
+        var errors = new List<ProducerValidationEventIssueRequest>();
+        var warnings = new List<ProducerValidationEventIssueRequest>();
+        var producerId = Guid.NewGuid().ToString();
+        var subsidiaryId = Guid.NewGuid().ToString();
+        var producer = BuildProducer(producerId);
+
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.Household, materialType: MaterialType.Plastic, quantityKg: "10000"));
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, subsidiaryId: subsidiaryId, packagingType: PackagingType.Household, materialType: MaterialType.Plastic, quantityKg: "5000"));
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.ClosedLoopRecycling, materialType: MaterialType.Plastic, quantityKg: "1000"));
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, subsidiaryId: subsidiaryId, packagingType: PackagingType.ClosedLoopRecycling, materialType: MaterialType.Plastic, quantityKg: "1000"));
+
+        // Act
+        await _systemUnderTest.ValidateAsync(producer.Rows, StoreKey, producer.BlobName, errors, warnings);
+
+        // Assert
+        warnings.Should().HaveCount(0);
+    }
+
+    [TestMethod]
+    public async Task ValidateAndAddWarning_ForDirectProducer_AcceptsRow_WhenTotalClrWeightIsTheSameAsOverallMaterialTypeWeight()
+    {
+        // Arrange
+        var errors = new List<ProducerValidationEventIssueRequest>();
+        var warnings = new List<ProducerValidationEventIssueRequest>();
+        var producerId = Guid.NewGuid().ToString();
+        var producer = BuildProducer(producerId);
+
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.Household, materialType: MaterialType.Plastic, quantityKg: "10000"));
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.ClosedLoopRecycling, materialType: MaterialType.Plastic, quantityKg: "10000"));
+
+        // Act
+        await _systemUnderTest.ValidateAsync(producer.Rows, StoreKey, producer.BlobName, errors, warnings);
+
+        // Assert
+        warnings.Should().HaveCount(0);
+    }
+
+    [TestMethod]
+    public async Task ValidateAndAddWarning_ForCSO_ForProducerAndSubsidiaries_AcceptsRow_WhenTotalClrWeightIsTheSameAsOverallMaterialTypeWeight()
+    {
+        // Arrange
+        var errors = new List<ProducerValidationEventIssueRequest>();
+        var warnings = new List<ProducerValidationEventIssueRequest>();
+        var producerId = Guid.NewGuid().ToString();
+        var subsidiaryId = Guid.NewGuid().ToString();
+        var producer = BuildProducer(producerId);
+
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.Household, materialType: MaterialType.Plastic, quantityKg: "10000"));
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, subsidiaryId: subsidiaryId, packagingType: PackagingType.Household, materialType: MaterialType.Plastic, quantityKg: "5000"));
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.ClosedLoopRecycling, materialType: MaterialType.Plastic, quantityKg: "10000"));
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, subsidiaryId: subsidiaryId, packagingType: PackagingType.ClosedLoopRecycling, materialType: MaterialType.Plastic, quantityKg: "5000"));
+
+        // Act
+        await _systemUnderTest.ValidateAsync(producer.Rows, StoreKey, producer.BlobName, errors, warnings);
+
+        // Assert
+        warnings.Should().HaveCount(0);
+    }
+
+    [TestMethod]
+    public async Task ValidateAndAddWarning_ForCSO_ForProducerAndSubsidiaries_AcceptsRow_WhenClrIsNotPresent()
+    {
+        // Arrange
+        var errors = new List<ProducerValidationEventIssueRequest>();
+        var warnings = new List<ProducerValidationEventIssueRequest>();
+        var producerId = Guid.NewGuid().ToString();
+        var subsidiaryId = Guid.NewGuid().ToString();
+        var producer = BuildProducer(producerId);
+
+        producer.Rows.Add(BuildProducerRow(producerId: producerId, packagingType: PackagingType.Household, materialType: MaterialType.Plastic, quantityKg: "10000"));
+
+        // Act
+        await _systemUnderTest.ValidateAsync(producer.Rows, StoreKey, producer.BlobName, errors, warnings);
+
+        // Assert
+        warnings.Should().HaveCount(0);
+    }
+
+    private static Producer BuildProducer(string producerId)
+    {
+        return new Producer(
+            Guid.NewGuid(),
+            producerId,
+            "BlobName",
+            []);
+    }
+
+    private ProducerRow BuildProducerRow(
+        string dataSubmissionPeriod = "2026-H1",
+        string submissionPeriod = "January to June 2026",
+        string subsidiaryId = "SubsidiaryId",
+        string producerId = "123456",
+        string producerType = ProducerType.SoldAsEmptyPackaging,
+        string producerSize = "ProducerSize",
+        string packagingType = PackagingType.HouseholdDrinksContainers,
+        string packagingCategory = PackagingClass.PrimaryPackaging,
+        string materialType = MaterialType.Aluminium,
+        string materialSubType = "MaterialSubType",
+        string fromHomeNation = "FromHomeNation",
+        string toHomeNation = "ToHomeNation",
+        string quantityKg = "QuantityKg",
+        string quantityUnits = "QuantityUnits",
+        string transitionalPackagingUnits = "TransitionalPackagingUnits",
+        string recyclabilityRating = "RecyclabilityRating") =>
+        new(
+            SubsidiaryId: subsidiaryId,
+            DataSubmissionPeriod: dataSubmissionPeriod,
+            SubmissionPeriod: submissionPeriod,
+            ProducerId: producerId,
+            RowNumber: _rowNumber++,
+            ProducerType: producerType,
+            ProducerSize: producerSize,
+            WasteType: packagingType,
+            PackagingCategory: packagingCategory,
+            MaterialType: materialType,
+            MaterialSubType: materialSubType,
+            FromHomeNation: fromHomeNation,
+            ToHomeNation: toHomeNation,
+            QuantityKg: quantityKg,
+            QuantityUnits: quantityUnits,
+            TransitionalPackagingUnits: transitionalPackagingUnits,
+            RecyclabilityRating: recyclabilityRating);
+}

--- a/src/EPR.ProducerContentValidation.Application/Constants/ErrorCode.cs
+++ b/src/EPR.ProducerContentValidation.Application/Constants/ErrorCode.cs
@@ -90,6 +90,7 @@ public static class ErrorCode
     public const string SubsidiaryIdDoesNotExist = "70";
     public const string SubsidiaryIdIsAssignedToADifferentOrganisation = "71";
     public const string SubsidiaryDoesNotBelongToAnyOrganisation = "72";
+    public const string WarningClosedLoopPackagingWeightGreaterThanWeightOfThatPackagingMaterialOverall = "74";
 
     /* Issue codes 80 through 89 should be reserved for Issues from the Check Splitter API */
     public const string UncaughtExceptionErrorCode = "99";

--- a/src/EPR.ProducerContentValidation.Application/Validators/GroupedValidator.cs
+++ b/src/EPR.ProducerContentValidation.Application/Validators/GroupedValidator.cs
@@ -56,14 +56,17 @@ public class GroupedValidator : IGroupedValidator
             // Warning Validators
             var singlePackagingMaterialValidator = new SinglePackagingMaterialGroupedValidator(_issueCountService);
             var totalPackagingMaterialValidator = new TotalPackagingMaterialValidator(_issueCountService);
+            var clrPackagingMaterialWeightValidator = new ClrPackagingMaterialWeightGroupedValidator(_issueCountService);
 
             var singlePackagingMaterialTask = singlePackagingMaterialValidator.ValidateAsync(producerRows, warningStoreKey, blobName, errorRows, warningRows);
             var totalPackagingMaterialValidatorTask = totalPackagingMaterialValidator.ValidateAsync(producerRows, warningStoreKey, blobName, errorRows, warningRows);
+            var clrPackagingMaterialWeightTask = clrPackagingMaterialWeightValidator.ValidateAsync(producerRows, warningStoreKey, blobName, errorRows, warningRows);
 
             groupedValidatorTasks.AddRange(new List<Task>
             {
                 singlePackagingMaterialTask,
-                totalPackagingMaterialValidatorTask
+                totalPackagingMaterialValidatorTask,
+                clrPackagingMaterialWeightTask
             });
         }
 

--- a/src/EPR.ProducerContentValidation.Application/Validators/GroupedValidators/AbstractGroupedValidator.cs
+++ b/src/EPR.ProducerContentValidation.Application/Validators/GroupedValidators/AbstractGroupedValidator.cs
@@ -17,6 +17,11 @@ public abstract class AbstractGroupedValidator : IAbstractGroupedValidator
 
     public abstract Task ValidateAsync(List<ProducerRow> producerRows, string storeKey, string blobName, List<ProducerValidationEventIssueRequest> errorRows = null, List<ProducerValidationEventIssueRequest>? warningRows = null);
 
+    protected static decimal ParseWeight(string quantityKg)
+    {
+        return decimal.TryParse(quantityKg, out var kg) ? kg : 0;
+    }
+
     protected async Task FindAndAddErrorAsync(ProducerRow row, string storeKey, ICollection<ProducerValidationEventIssueRequest> issueRows, string errorCode, string blobName)
     {
         var errorRow = issueRows.FirstOrDefault(x => x.RowNumber == row.RowNumber);

--- a/src/EPR.ProducerContentValidation.Application/Validators/GroupedValidators/WarningValidators/ClrPackagingMaterialWeightGroupedValidator.cs
+++ b/src/EPR.ProducerContentValidation.Application/Validators/GroupedValidators/WarningValidators/ClrPackagingMaterialWeightGroupedValidator.cs
@@ -1,0 +1,67 @@
+﻿using EPR.ProducerContentValidation.Application.Constants;
+using EPR.ProducerContentValidation.Application.DTOs.SubmissionApi;
+using EPR.ProducerContentValidation.Application.Models;
+using EPR.ProducerContentValidation.Application.Services.Interfaces;
+
+namespace EPR.ProducerContentValidation.Application.Validators.GroupedValidators.WarningValidators;
+
+public class ClrPackagingMaterialWeightGroupedValidator(IIssueCountService issueCountService)
+    : AbstractGroupedValidator(issueCountService)
+{
+    private readonly IIssueCountService _issueCountService = issueCountService;
+    private readonly List<string> _skipRuleErrorCodes =
+    [
+        ErrorCode.PackagingTypeInvalidErrorCode,
+        ErrorCode.QuantityKgInvalidErrorCode
+    ];
+
+    public override async Task ValidateAsync(List<ProducerRow> producerRows, string storeKey, string blobName, List<ProducerValidationEventIssueRequest> errorRows = null, List<ProducerValidationEventIssueRequest>? warningRows = null)
+    {
+        var associatedErrorRows = errorRows
+            .Where(x => producerRows.Exists(y => y.RowNumber == x.RowNumber))
+            .ToList();
+        var shouldSkip = associatedErrorRows
+            .Exists(x => x.ErrorCodes.Exists(y => _skipRuleErrorCodes.Contains(y)));
+        var remainingWarningCountToProcess = await _issueCountService.GetRemainingIssueCapacityAsync(storeKey);
+
+        if (shouldSkip || remainingWarningCountToProcess == 0)
+        {
+            return;
+        }
+
+        // distinct list of packaging materials that include a CLR entry, by producer
+        var materialRows = producerRows.Where(row => row.WasteType == PackagingType.ClosedLoopRecycling)
+            .Select(row => row.MaterialType).Distinct().ToList();
+
+        if (materialRows.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var materialType in materialRows)
+        {
+            // total CLR weight
+            var filteredClrRows = producerRows.Where(row => row.MaterialType == materialType && row.WasteType == PackagingType.ClosedLoopRecycling).ToList();
+            var totalClrWeight = filteredClrRows.Sum(row => ParseWeight(row.QuantityKg));
+
+            // total material weight
+            var filteredMaterialRows = producerRows.Where(row => row.MaterialType == materialType && row.WasteType != PackagingType.ClosedLoopRecycling);
+            var totalMaterialWeight = filteredMaterialRows.Sum(row => ParseWeight(row.QuantityKg));
+
+            // validation check
+            if (totalClrWeight <= totalMaterialWeight)
+            {
+                continue;
+            }
+
+            // add an error if validation check failed
+            var representativeRow = filteredClrRows.FirstOrDefault();
+            if (representativeRow == null)
+            {
+                continue;
+            }
+
+            await FindAndAddErrorAsync(representativeRow, storeKey, warningRows, ErrorCode.WarningClosedLoopPackagingWeightGreaterThanWeightOfThatPackagingMaterialOverall, blobName);
+        }
+    }
+}

--- a/src/EPR.ProducerContentValidation.Application/Validators/GroupedValidators/WarningValidators/ClrPackagingMaterialWeightGroupedValidator.cs
+++ b/src/EPR.ProducerContentValidation.Application/Validators/GroupedValidators/WarningValidators/ClrPackagingMaterialWeightGroupedValidator.cs
@@ -29,7 +29,7 @@ public class ClrPackagingMaterialWeightGroupedValidator(IIssueCountService issue
             return;
         }
 
-        // distinct list of packaging materials that include a CLR entry, by producer
+        // distinct list of packaging materials that include a CLR entry
         var materialRows = producerRows.Where(row => row.WasteType == PackagingType.ClosedLoopRecycling)
             .Select(row => row.MaterialType).Distinct().ToList();
 

--- a/src/EPR.ProducerContentValidation.Application/Validators/GroupedValidators/WarningValidators/TotalPackagingMaterialValidator.cs
+++ b/src/EPR.ProducerContentValidation.Application/Validators/GroupedValidators/WarningValidators/TotalPackagingMaterialValidator.cs
@@ -61,9 +61,4 @@ public class TotalPackagingMaterialValidator : AbstractGroupedValidator
 
         await FindAndAddErrorAsync(representativeRow, storeKey, warningRows, ErrorCode.WarningPackagingMaterialWeightLessThanLimitKg, blobName);
     }
-
-    private static decimal ParseWeight(string quantityKg)
-    {
-        return decimal.TryParse(quantityKg, out var kg) ? kg : 0;
-    }
 }


### PR DESCRIPTION
Add a new warning-validator that checks the weight of the CLR entry for a particular material type is not greater than the total weight of the particular material overall, for any other packaging type, across the producer and any subsidiaries, if relevant. Although this is to guard against claiming more offset against the ultimate bill than is physically possible, the ticket requires this be a "warning" only. Added tests to cover and moved a reused helper method to the base grouped validator class.