### PR TITLE
Pass envToDeploy to common deployment template

### DIFF
--- a/pipelines/deployment-pipeline.yaml
+++ b/pipelines/deployment-pipeline.yaml
@@ -97,6 +97,7 @@ resources:
 extends:
   template: epr-funcs-deployment-pipeline.yaml@CommonTemplates
   parameters:
+    envToDeploy: ${{ parameters.envToDeploy }}
     ${{ if contains(parameters.imageTag, 'RELEASE') }}:
       imageTag: $(DEVRWDWEBFAx402)
     ${{ else }}:


### PR DESCRIPTION
## Summary
Adds an `envToDeploy` parameter to the common deployment template invocation so this service routes to the correct agent pool per environment.

## Why
Prod-like environments (`prd`, `pre1`, `pre2`) need to run on the SSV5 agent pools, while non-prod (`dev`, `tst`) stays on SSV3. The shared template in `epr-webapps-code-deploy-templates` picks the pool inside `${{ if }}` template expressions, which Azure DevOps evaluates at **compile time** — before runtime values resolve.

The previous logic substring-matched `targetEnvironment`, but that parameter is passed across the template boundary as a runtime variable expression, which is never resolved at compile time, so prod-like deployments weren't being routed to SSV5. `envToDeploy` is a template parameter that resolves at expansion time, so the `${{ if }}` can actually evaluate it.

Template-side change: DEFRA/epr-webapps-code-deploy-templates#31

## Changes
- Add `envToDeploy: ${{ parameters.envToDeploy }}` under the existing `parameters:` block of the pipeline. No other changes.

## Risk
Low. `envToDeploy` defaults to `''` on the template side, so behaviour is unchanged for any service that hasn't been updated yet. Once merged, this service's prod-like deployments will use SSV5 and non-prod will continue on SSV3 as before.