### PR TITLE
Bug/sub 271 plug hole in ramrag assessment validation

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -30,6 +30,4 @@ services:
       HttpEndpoint__Enabled: "true"
       Validation__Disabled: "false"
       Validation__MaxIssuesToProcess: "1000"
-      FeatureManagement__EnableLargeProducerEnhancedRecyclabilityRatingValidation: "true"
-      FeatureManagement__EnableLargeProducerRecyclabilityRatingValidation: "true"
       FeatureManagement__EnableSubsidiaryValidationPom: "true"

--- a/src/EPR.ProducerContentValidation.Application.UnitTests/Validators/CompositeValidatorTests.cs
+++ b/src/EPR.ProducerContentValidation.Application.UnitTests/Validators/CompositeValidatorTests.cs
@@ -36,7 +36,7 @@ public class CompositeValidatorTests
     private readonly Mock<IValidator<ProducerRow>> _producerRowValidatorMock;
     private readonly Mock<ValidationFailure> _validationFailureMock;
     private readonly Mock<ValidationResult> _validationResultMock;
-    private Mock<IFeatureManager> _featureManagerMock;
+    private readonly Mock<IFeatureManager> _featureManagerMock;
 
     private ValidationOptions _options;
 
@@ -76,7 +76,7 @@ public class CompositeValidatorTests
         var validationFailuresList = new List<ValidationFailure> { _validationFailureMock.Object };
         _validationResultMock.Object.Errors = validationFailuresList;
 
-        _producerRowValidatorMock.Setup(x => x.ValidateAsync(It.IsAny<ValidationContext<ProducerRow>>(), default))
+        _producerRowValidatorMock.Setup(x => x.ValidateAsync(It.IsAny<ValidationContext<ProducerRow>>(), CancellationToken.None))
             .ReturnsAsync(_validationResultMock.Object);
 
         _producerRowValidatorMock.Setup(x => x.ValidateAsync(It.IsAny<ProducerRow>(), default))
@@ -85,7 +85,6 @@ public class CompositeValidatorTests
         _serviceUnderTest = new CompositeValidator(
             Microsoft.Extensions.Options.Options.Create(_options),
             Microsoft.Extensions.Options.Options.Create(submissionPeriodOptions),
-            _featureManagerMock.Object,
             _issueCountServiceMock.Object,
             _producerRowValidatorFactoryMock.Object,
             _producerRowWarningValidatorFactoryMock.Object,
@@ -413,7 +412,6 @@ public class CompositeValidatorTests
         var compositeValidator = new CompositeValidator(
             Microsoft.Extensions.Options.Options.Create(_options),
             Microsoft.Extensions.Options.Options.Create(submissionPeriodOptions),
-            _featureManagerMock.Object,
             _issueCountServiceMock.Object,
             producerRowValidatorFactory,
             producerRowWarningValidatorFactory,
@@ -506,7 +504,6 @@ public class CompositeValidatorTests
         _serviceUnderTest = new CompositeValidator(
             Microsoft.Extensions.Options.Options.Create(_options),
             submissionPeriodOptions.Object,
-            _featureManagerMock.Object,
             _issueCountServiceMock.Object,
             _producerRowValidatorFactoryMock.Object,
             _producerRowWarningValidatorFactoryMock.Object,

--- a/src/EPR.ProducerContentValidation.Application.UnitTests/Validators/CompositeValidatorTests.cs
+++ b/src/EPR.ProducerContentValidation.Application.UnitTests/Validators/CompositeValidatorTests.cs
@@ -82,8 +82,6 @@ public class CompositeValidatorTests
         _producerRowValidatorMock.Setup(x => x.ValidateAsync(It.IsAny<ProducerRow>(), default))
             .ReturnsAsync(_validationResultMock.Object);
 
-        _featureManagerMock.Setup(x => x.IsEnabledAsync(FeatureFlags.EnableLargeProducerRecyclabilityRatingValidation)).ReturnsAsync(true);
-
         _serviceUnderTest = new CompositeValidator(
             Microsoft.Extensions.Options.Options.Create(_options),
             Microsoft.Extensions.Options.Options.Create(submissionPeriodOptions),

--- a/src/EPR.ProducerContentValidation.Application.UnitTests/Validators/PropertyValidators/MaterialSubMaterialCombinationValidatorTests.cs
+++ b/src/EPR.ProducerContentValidation.Application.UnitTests/Validators/PropertyValidators/MaterialSubMaterialCombinationValidatorTests.cs
@@ -357,7 +357,6 @@ public class MaterialSubMaterialCombinationValidatorTests : MaterialSubMaterialC
         var producerRow = BuildProducerRow(dataSubmissionPeriod, producerType, producerSize, packagingType, packagingClass, materialType, materialSubType, null);
 
         var context = new ValidationContext<ProducerRow>(producerRow);
-        context.RootContextData[FeatureFlags.EnableLargeProducerRecyclabilityRatingValidation] = false;
 
         // Act
         var result = _systemUnderTest.TestValidate(context);
@@ -460,7 +459,6 @@ public class MaterialSubMaterialCombinationValidatorTests : MaterialSubMaterialC
     {
         var row = new ProducerRow(null, period, null, 1, "SO", orgSize, pkgType, pkgClass, material, subType, null, null, null, null, null, null, null);
         var context = new ValidationContext<ProducerRow>(row);
-        context.RootContextData[FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation] = true;
 
         var validator = new MaterialSubMaterialCombinationValidator();
         var result = validator.TestValidate(context);
@@ -475,7 +473,6 @@ public class MaterialSubMaterialCombinationValidatorTests : MaterialSubMaterialC
     {
         var row = new ProducerRow(null, period, null, 1, "SO", orgSize, pkgType, pkgClass, material, subType, null, null, null, null, null, null, null);
         var context = new ValidationContext<ProducerRow>(row);
-        context.RootContextData[FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation] = true;
 
         var validator = new MaterialSubMaterialCombinationValidator();
         var result = validator.TestValidate(context);
@@ -493,7 +490,6 @@ public class MaterialSubMaterialCombinationValidatorTests : MaterialSubMaterialC
     {
         var row = new ProducerRow(null, period, null, 1, "SO", orgSize, pkgType, pkgClass, material, subType, null, null, null, null, null, null, null);
         var context = new ValidationContext<ProducerRow>(row);
-        context.RootContextData[FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation] = true;
 
         var validator = new MaterialSubMaterialCombinationValidator();
         var result = validator.TestValidate(context);
@@ -509,14 +505,12 @@ public class MaterialSubMaterialCombinationValidatorTests : MaterialSubMaterialC
     [DataRow("2025-H2", "L", PackagingType.SelfManagedConsumerWaste, PackagingClass.PublicBin, MaterialType.Plastic, "Random", ErrorCode.PackagingMaterialSubtypeNotNeededForPackagingMaterial)]
     [DataRow("2025-H1", "L", PackagingType.ReusablePackaging, PackagingClass.PublicBin, MaterialType.Plastic, MaterialSubType.HDPE, ErrorCode.PackagingMaterialSubtypeNotNeededForPackagingMaterial)]
     [DataRow("2025-H2", "L", PackagingType.HouseholdDrinksContainers, PackagingClass.PublicBin, MaterialType.Plastic, MaterialSubType.Rigid, ErrorCode.PackagingMaterialSubtypeNotNeededForPackagingMaterial)]
-    public void Should_Fail_When_Packingtype_Is_Nonhousehold_And_MaterialSubtype_isnotempty(string period, string orgSize, string pkgType, string pkgClass, string material, string subType, string expectedError)
+    public void Should_Fail_When_Packingtype_Is_Nonhousehold_And_MaterialSubtype_IsNotEmpty(string period, string orgSize, string pkgType, string pkgClass, string material, string subType, string expectedError)
     {
         var row = new ProducerRow(null, period, null, 1, "SO", orgSize, pkgType, pkgClass, material, subType, null, null, null, null, null, null, null);
-        var context = new ValidationContext<ProducerRow>(row);
-        context.RootContextData[FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation] = true;
 
         var validator = new MaterialSubMaterialCombinationValidator();
-        var result = validator.TestValidate(context);
+        var result = validator.TestValidate(new ValidationContext<ProducerRow>(row));
 
         result.ShouldHaveValidationErrorFor(x => x.MaterialSubType)
               .WithErrorCode(expectedError);

--- a/src/EPR.ProducerContentValidation.Application.UnitTests/Validators/PropertyValidators/RecyclabilityRatingValidatorTests.cs
+++ b/src/EPR.ProducerContentValidation.Application.UnitTests/Validators/PropertyValidators/RecyclabilityRatingValidatorTests.cs
@@ -6,21 +6,17 @@ using FluentAssertions;
 using FluentValidation;
 using FluentValidation.Results;
 using FluentValidation.TestHelper;
-using Microsoft.FeatureManagement;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Models;
-using Moq;
 
 [TestClass]
 public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
 {
     private readonly RecyclabilityRatingValidator _systemUnderTest;
-    private Mock<IFeatureManager> _featureManagerMock;
 
     public RecyclabilityRatingValidatorTests()
     {
         _systemUnderTest = new RecyclabilityRatingValidator();
-        _featureManagerMock = new Mock<IFeatureManager>();
     }
 
     [TestMethod]
@@ -69,7 +65,7 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
         var producerRow = BuildProducerRow(dataSubmissionPeriod, producerType, producerSize, packagingType, packagingClass, materialType, materialSubType, recyclabilityRating);
 
         // Act
-        var result = _systemUnderTest.TestValidate(CreateContextWithFeatureFlag(producerRow));
+        var result = _systemUnderTest.TestValidate(new ValidationContext<ProducerRow>(producerRow));
 
         // Assert
         result.ShouldHaveValidationErrorFor(x => x.RecyclabilityRating)
@@ -77,14 +73,12 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
     }
 
     [TestMethod]
-    [DataRow(true, DataSubmissionPeriodTestData.Year2025H1, ProducerType.SuppliedUnderYourBrand, ProducerSize.Large, PackagingType.Household, PackagingClass.PrimaryPackaging, MaterialType.Aluminium, MaterialSubType.Flexible)]
-    [DataRow(false, DataSubmissionPeriodTestData.Year2025H1, ProducerType.SuppliedUnderYourBrand, ProducerSize.Large, PackagingType.Household, PackagingClass.PrimaryPackaging, MaterialType.Aluminium, MaterialSubType.Flexible)]
-    [DataRow(true, DataSubmissionPeriodTestData.Year2025H1, ProducerType.SuppliedUnderYourBrand, ProducerSize.Large, PackagingType.Household, PackagingClass.PrimaryPackaging, MaterialType.Plastic, MaterialSubType.Rigid)]
-    [DataRow(false, DataSubmissionPeriodTestData.Year2025H1, ProducerType.SuppliedUnderYourBrand, ProducerSize.Large, PackagingType.Household, PackagingClass.PrimaryPackaging, MaterialType.Plastic, MaterialSubType.Rigid)]
-    [DataRow(true, DataSubmissionPeriodTestData.Year2025H1, ProducerType.SuppliedUnderYourBrand, ProducerSize.Large, PackagingType.Household, PackagingClass.PrimaryPackaging, MaterialType.PaperCard, "")]
-    [DataRow(false, DataSubmissionPeriodTestData.Year2025H1, ProducerType.SuppliedUnderYourBrand, ProducerSize.Large, PackagingType.Household, PackagingClass.PrimaryPackaging, MaterialType.PaperCard, "")]
-    public void LargeProducerRecyclabilityRatingValidator_Missing_Recyclability_Code_Validation_Varies_BasedOn_FeatureFlag(
-        bool isFeatureFlagEnabled,
+    [DataRow(DataSubmissionPeriodTestData.Year2025H1, ProducerType.SuppliedUnderYourBrand, ProducerSize.Large, PackagingType.Household, PackagingClass.PrimaryPackaging, MaterialType.Aluminium, MaterialSubType.Flexible)]
+    [DataRow(DataSubmissionPeriodTestData.Year2025H1, ProducerType.SuppliedUnderYourBrand, ProducerSize.Large, PackagingType.Household, PackagingClass.PrimaryPackaging, MaterialType.Plastic, MaterialSubType.Rigid)]
+    [DataRow(DataSubmissionPeriodTestData.Year2025H1, ProducerType.SuppliedUnderYourBrand, ProducerSize.Large, PackagingType.Household, PackagingClass.PrimaryPackaging, MaterialType.PaperCard, "")]
+    [DataRow(DataSubmissionPeriodTestData.Year2025H1, ProducerType.SuppliedUnderYourBrand, ProducerSize.Large, PackagingType.PublicBin, PackagingClass.PrimaryPackaging, MaterialType.Wood, "")]
+    [DataRow(DataSubmissionPeriodTestData.Year2025H1, ProducerType.SuppliedUnderYourBrand, ProducerSize.Large, PackagingType.HouseholdDrinksContainers, PackagingClass.PrimaryPackaging, MaterialType.Glass, "")]
+    public void LargeProducerRecyclabilityRatingValidator_Missing_Recyclability_Code_Validation(
         string dataSubmissionPeriod,
         string producerType,
         string producerSize,
@@ -95,21 +89,12 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
     {
         // Arrange
         var producerRow = BuildProducerRow(dataSubmissionPeriod, producerType, producerSize, packagingType, packagingClass, materialType, materialSubType, null);
-        var context = CreateContextWithFeatureFlag(producerRow, isFeatureFlagEnabled);
 
         // Act
-        var result = _systemUnderTest.TestValidate(context);
+        var result = _systemUnderTest.TestValidate(new ValidationContext<ProducerRow>(producerRow));
 
         // Assert
-        if (isFeatureFlagEnabled)
-        {
-            result.ShouldNotHaveValidationErrorFor(x => x.RecyclabilityRating);
-        }
-        else
-        {
-            result.ShouldHaveValidationErrorFor(x => x.RecyclabilityRating)
-                 .WithErrorCode(ErrorCode.LargeProducerRecyclabilityRatingRequired);
-        }
+        result.ShouldNotHaveValidationErrorFor(x => x.RecyclabilityRating);
     }
 
     [TestMethod]
@@ -123,7 +108,7 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
         var producerRow = BuildProducerRow(dataSubmissionPeriod, producerType, producerSize, packagingType, packagingClass, materialType, materialSubType, recyclabilityRating);
 
         // Act
-        var result = _systemUnderTest.TestValidate(CreateContextWithFeatureFlag(producerRow));
+        var result = _systemUnderTest.TestValidate(new ValidationContext<ProducerRow>(producerRow));
 
         // Assert
         result.ShouldHaveValidationErrorFor(x => x.RecyclabilityRating)
@@ -169,29 +154,25 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
     }
 
     [TestMethod]
-    [DataRow(true, "Z")]
-    [DataRow(false, "INVALID")]
-    public void InvalidRecyclabilityRating_ShouldRaiseError_WhenPresent(bool isFlagOn, string rating)
+    public void InvalidRecyclabilityRating_ShouldRaiseError_WhenPresent()
     {
+        const string rating = "Z";
         var row = BuildProducerRow(DataSubmissionPeriodTestData.Year2025H1, ProducerType.SuppliedUnderYourBrand, ProducerSize.Large, PackagingType.Household, PackagingClass.PrimaryPackaging, MaterialType.PaperCard, string.Empty, rating);
-        var context = CreateContextWithFeatureFlag(row, isFlagOn);
 
-        var result = _systemUnderTest.TestValidate(context);
+        var result = _systemUnderTest.TestValidate(new ValidationContext<ProducerRow>(row));
 
-        var expectedErrorCode = isFlagOn ? ErrorCode.LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode : ErrorCode.LargeProducerRecyclabilityRatingInvalidErrorCode;
+        const string expectedErrorCode = ErrorCode.LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode;
 
         result.ShouldHaveValidationErrorFor(x => x.RecyclabilityRating)
               .WithErrorCode(expectedErrorCode);
     }
 
     [TestMethod]
-    [DataRow(true)]
-    [DataRow(false)]
-    public void RecyclabilityRating_NotRequiredBefore2025_ShouldRaiseError_WhenProvided(bool isFlagOn)
+    public void RecyclabilityRating_NotRequiredBefore2025_ShouldRaiseError_WhenProvided()
     {
-        // TO DO not requried to test for AC9
+        // TO DO not required to test for AC9
         var row = BuildProducerRow("2024-P1", ProducerType.SuppliedUnderYourBrand, ProducerSize.Large, PackagingType.Household, PackagingClass.PrimaryPackaging, MaterialType.Aluminium, string.Empty, RecyclabilityRating.Green);
-        var context = CreateContextWithFeatureFlag(row, isFlagOn);
+        var context = new ValidationContext<ProducerRow>(row);
 
         var result = _systemUnderTest.TestValidate(context);
 
@@ -200,12 +181,10 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
     }
 
     [TestMethod]
-    [DataRow(true, "2025-H1", "L", PackagingType.Household, PackagingClass.PrimaryPackaging, MaterialType.Glass, "", "Invalid", ErrorCode.LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode)]
-    [DataRow(true, "2025-H2", "L", PackagingType.PublicBin, PackagingClass.PublicBin, MaterialType.Aluminium, "", "123", ErrorCode.LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode)]
-    [DataRow(false, "2025-H1", "L", PackagingType.Household, PackagingClass.PrimaryPackaging, MaterialType.Glass, "", "Invalid", ErrorCode.LargeProducerRecyclabilityRatingInvalidErrorCode)]
-    [DataRow(false, "2025-H2", "L", PackagingType.PublicBin, PackagingClass.PublicBin, MaterialType.Aluminium, "", "123", ErrorCode.LargeProducerRecyclabilityRatingInvalidErrorCode)]
-    public void Should_Fail_When_InvalidRecyclabilityCode_WithCorrectErrorCodeBasedOnFlag(
-        bool featureFlagOn,
+    [DataRow("2025-H1", "L", PackagingType.Household, PackagingClass.PrimaryPackaging, MaterialType.Glass, "", "Invalid", ErrorCode.LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode)]
+    [DataRow("2025-H2", "L", PackagingType.PublicBin, PackagingClass.PublicBin, MaterialType.Aluminium, "", "123", ErrorCode.LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode)]
+    [DataRow("2025-H2", "L", PackagingType.HouseholdDrinksContainers, "", MaterialType.Glass, "", "Fake", ErrorCode.LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode)]
+    public void Should_Fail_When_InvalidRecyclabilityCode_WithCorrectErrorCode(
         string period,
         string orgSize,
         string pkgType,
@@ -217,7 +196,6 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
     {
         var row = new ProducerRow(null, period, null, 1, "SO", orgSize, pkgType, pkgClass, material, subType, null, null, null, null, null, null, rating);
         var context = new ValidationContext<ProducerRow>(row);
-        context.RootContextData[FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation] = featureFlagOn;
 
         var validator = new RecyclabilityRatingValidator();
         var result = validator.TestValidate(context);
@@ -227,10 +205,8 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
     }
 
     [TestMethod]
-    [DataRow(true, "2025-H2", "L", PackagingType.HouseholdDrinksContainers, "", MaterialType.Glass, "", "Fake", ErrorCode.LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode)]
-    [DataRow(false, "2025-H2", "L", PackagingType.HouseholdDrinksContainers, "", MaterialType.Glass, "", "Fake", ErrorCode.LargeProducerRecyclabilityRatingInvalidErrorCode)]
-    public void Should_Not_Fail_When_InvalidRecyclabilityCode_WithCorrectErrorCodeBasedOnFlag(
-      bool featureFlagOn,
+    [DataRow("2025-H2", "L", PackagingType.HouseholdDrinksContainers, "", MaterialType.Glass, "", "A", ErrorCode.LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode)]
+    public void Should_Not_Fail_When_InvalidRecyclabilityCode_WithCorrectErrorCode(
       string period,
       string orgSize,
       string pkgType,
@@ -242,7 +218,6 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
     {
         var row = new ProducerRow(null, period, null, 1, "SO", orgSize, pkgType, pkgClass, material, subType, null, null, null, null, null, null, rating);
         var context = new ValidationContext<ProducerRow>(row);
-        context.RootContextData[FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation] = featureFlagOn;
 
         var validator = new RecyclabilityRatingValidator();
         var result = validator.TestValidate(context);
@@ -257,7 +232,6 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
     {
         var row = new ProducerRow(null, period, null, 1, "SO", orgSize, pkgType, pkgClass, material, subType, null, null, null, null, null, null, null);
         var context = new ValidationContext<ProducerRow>(row);
-        context.RootContextData[FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation] = true;
 
         var validator = new MaterialSubMaterialCombinationValidator();
         var result = validator.TestValidate(context);
@@ -274,7 +248,6 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
     {
         var row = new ProducerRow(null, period, null, 1, "SO", orgSize, pkgType, pkgClass, material, subType, null, null, null, null, null, null, rating);
         var context = new ValidationContext<ProducerRow>(row);
-        context.RootContextData[FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation] = true;
 
         var validator = new RecyclabilityRatingValidator();
         var result = validator.TestValidate(context);
@@ -293,7 +266,6 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
     {
         var row = new ProducerRow(null, period, null, 1, "SO", orgSize, pkgType, pkgClass, material, subType, null, null, null, null, null, null, rating);
         var context = new ValidationContext<ProducerRow>(row);
-        context.RootContextData[FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation] = true;
 
         var validator = new RecyclabilityRatingValidator();
         var result = validator.TestValidate(context);
@@ -309,7 +281,7 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
     [DataRow(ProducerSize.Large, PackagingType.HouseholdDrinksContainers, MaterialType.Plastic, ErrorCode.LargeProducerInvalidForWasteAndMaterialType, DataSubmissionPeriodTestData.Year2025H1)]
     [DataRow(ProducerSize.Large, PackagingType.SmallOrganisationPackagingAll, MaterialType.Steel)]
     [DataRow(ProducerSize.Small, PackagingType.PublicBin, MaterialType.Glass, ErrorCode.SmallProducerRecyclabilityRatingNotRequired)]
-    public void Should_Fail_When_RecyclabilityRating_Provided_For_InvalidWasteAndMaterialType_WhenFlagEnabled(
+    public void Should_Fail_When_RecyclabilityRating_Provided_For_InvalidWasteAndMaterialType(
         string producerSize,
         string packagingType,
         string materialType,
@@ -326,9 +298,7 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
             materialSubType: MaterialSubType.Rigid,
             recyclabilityRating: RecyclabilityRating.Red);
 
-        var context = CreateContextWithFeatureFlag(row, isEnabled: true);
-
-        var result = _systemUnderTest.TestValidate(context);
+        var result = _systemUnderTest.TestValidate(new ValidationContext<ProducerRow>(row));
 
         Assert.AreEqual(1, result.Errors.Count);
 
@@ -337,9 +307,10 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
     }
 
     [TestMethod]
-    [DataRow(ProducerSize.Large, PackagingType.HouseholdDrinksContainers, MaterialType.Glass, DataSubmissionPeriodTestData.Year2024P2)]
-    [DataRow(ProducerSize.Large, PackagingType.HouseholdDrinksContainers, MaterialType.Glass, DataSubmissionPeriodTestData.Year2023P3)]
-    public void Should_Not_Fail_When_RecyclabilityRating_Provided_For_InvalidWasteAndMaterialType_For_OtherThan_2025_WhenFlagEnabled(string producerSize, string packagingType, string materialType, string submissionPeriod)
+    [DataRow(ProducerSize.Large, PackagingType.HouseholdDrinksContainers, MaterialType.Glass, DataSubmissionPeriodTestData.Year2025P0, " A")]
+    [DataRow(ProducerSize.Large, PackagingType.HouseholdDrinksContainers, MaterialType.Glass, DataSubmissionPeriodTestData.Year2025P0, "A ")]
+    [DataRow(ProducerSize.Large, PackagingType.HouseholdDrinksContainers, MaterialType.Glass, DataSubmissionPeriodTestData.Year2025P0, "A_M")]
+    public void Should_Fail_When_InvalidRecyclabilityRating_Provided_After_2024(string producerSize, string packagingType, string materialType, string submissionPeriod, string recyclabilityRating)
     {
         var row = BuildProducerRow(
             dataSubmissionPeriod: submissionPeriod,
@@ -348,17 +319,15 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
             packagingType: packagingType,
             packagingClass: PackagingClass.PrimaryPackaging,
             materialType: materialType,
-            materialSubType: MaterialSubType.Rigid,
-            recyclabilityRating: RecyclabilityRating.Red);
+            materialSubType: string.Empty,
+            recyclabilityRating: recyclabilityRating);
 
-        var context = CreateContextWithFeatureFlag(row, isEnabled: true);
-
-        var result = _systemUnderTest.TestValidate(context);
+        var result = _systemUnderTest.TestValidate(new ValidationContext<ProducerRow>(row));
 
         Assert.AreEqual(1, result.Errors.Count);
 
         result.ShouldHaveValidationErrorFor(x => x.RecyclabilityRating)
-             .WithErrorCode(ErrorCode.LargeProducerRecyclabilityRatingNotRequired);
+             .WithErrorCode(ErrorCode.LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode);
     }
 
     [TestMethod]
@@ -367,7 +336,7 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
     [DataRow(ProducerSize.Large, PackagingType.PublicBin, MaterialType.Aluminium)]
     [DataRow(ProducerSize.Large, PackagingType.PublicBin, MaterialType.Glass)]
     [DataRow(ProducerSize.Large, PackagingType.HouseholdDrinksContainers, MaterialType.Glass)]
-    public void Should_Pass_When_RecyclabilityRating_Provided_For_ValidWasteAndMaterialType_WhenFlagEnabled(string producerSize, string packagingType, string materialType)
+    public void Should_Pass_When_RecyclabilityRating_Provided_For_ValidWasteAndMaterialType(string producerSize, string packagingType, string materialType)
     {
         var row = BuildProducerRow(
             dataSubmissionPeriod: DataSubmissionPeriodTestData.Year2025H1,
@@ -379,11 +348,106 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
             materialSubType: MaterialSubType.Rigid,
             recyclabilityRating: RecyclabilityRating.Green);
 
-        var context = CreateContextWithFeatureFlag(row, isEnabled: true);
-
-        var result = _systemUnderTest.TestValidate(context);
+        var result = _systemUnderTest.TestValidate(new ValidationContext<ProducerRow>(row));
 
         result.ShouldNotHaveValidationErrorFor(x => x.RecyclabilityRating);
+    }
+
+    [TestMethod]
+    [DataRow(ProducerSize.Large, PackagingType.HouseholdDrinksContainers, MaterialType.Glass, "", DataSubmissionPeriodTestData.Year2025H1, "A")]
+    [DataRow(ProducerSize.Large, PackagingType.PublicBin, MaterialType.PaperCard, "", DataSubmissionPeriodTestData.Year2025H1, "A")]
+    [DataRow(ProducerSize.Large, PackagingType.Household, MaterialType.Plastic, MaterialSubType.Rigid, DataSubmissionPeriodTestData.Year2025H1, "A")]
+    [DataRow(ProducerSize.Large, PackagingType.Household, MaterialType.Plastic, MaterialSubType.Flexible,  DataSubmissionPeriodTestData.Year2025H1, "A")]
+    public void Should_Pass_When_Valid_But_Optional_RecyclabilityRating_Provided_During_2025H1_Only(string producerSize, string packagingType, string materialType, string materialSubType, string submissionPeriod, string recyclabilityRating)
+    {
+        var row = BuildProducerRow(
+            dataSubmissionPeriod: submissionPeriod,
+            producerType: ProducerType.SuppliedUnderYourBrand,
+            producerSize: producerSize,
+            packagingType: packagingType,
+            packagingClass: PackagingClass.PrimaryPackaging,
+            materialType: materialType,
+            materialSubType: materialSubType,
+            recyclabilityRating: recyclabilityRating);
+
+        var result = _systemUnderTest.TestValidate(new ValidationContext<ProducerRow>(row));
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [TestMethod]
+    [DataRow(ProducerSize.Large, PackagingType.HouseholdDrinksContainers, MaterialType.Glass, "", DataSubmissionPeriodTestData.Year2025H1)]
+    [DataRow(ProducerSize.Large, PackagingType.PublicBin, MaterialType.PaperCard, "", DataSubmissionPeriodTestData.Year2025H1)]
+    [DataRow(ProducerSize.Large, PackagingType.Household, MaterialType.Plastic, MaterialSubType.Rigid, DataSubmissionPeriodTestData.Year2025H1)]
+    [DataRow(ProducerSize.Large, PackagingType.Household, MaterialType.Plastic, MaterialSubType.Flexible,  DataSubmissionPeriodTestData.Year2025H1)]
+    public void Should_Pass_When_No_Rating_Supplied_For_Matching_MaterialTypes_During_2025H1_Only(string producerSize, string packagingType, string materialType, string materialSubType, string submissionPeriod)
+    {
+        var row = BuildProducerRow(
+            dataSubmissionPeriod: submissionPeriod,
+            producerType: ProducerType.SuppliedUnderYourBrand,
+            producerSize: producerSize,
+            packagingType: packagingType,
+            packagingClass: PackagingClass.PrimaryPackaging,
+            materialType: materialType,
+            materialSubType: materialSubType,
+            recyclabilityRating: string.Empty);
+
+        var result = _systemUnderTest.TestValidate(new ValidationContext<ProducerRow>(row));
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [TestMethod]
+    [DataRow(ProducerSize.Large, PackagingType.HouseholdDrinksContainers, MaterialType.Glass, "", DataSubmissionPeriodTestData.Year2025H2)]
+    [DataRow(ProducerSize.Large, PackagingType.PublicBin, MaterialType.PaperCard, "", DataSubmissionPeriodTestData.Year2025H2)]
+    [DataRow(ProducerSize.Large, PackagingType.Household, MaterialType.Plastic, MaterialSubType.Rigid, DataSubmissionPeriodTestData.Year2025H2)]
+    [DataRow(ProducerSize.Large, PackagingType.Household, MaterialType.Plastic, MaterialSubType.Flexible,  DataSubmissionPeriodTestData.Year2025H2)]
+    [DataRow(ProducerSize.Large, PackagingType.HouseholdDrinksContainers, MaterialType.Glass, "", DataSubmissionPeriodTestData.Year2026H1)]
+    [DataRow(ProducerSize.Large, PackagingType.PublicBin, MaterialType.PaperCard, "", DataSubmissionPeriodTestData.Year2026H1)]
+    [DataRow(ProducerSize.Large, PackagingType.Household, MaterialType.Plastic, MaterialSubType.Rigid, DataSubmissionPeriodTestData.Year2026H1)]
+    [DataRow(ProducerSize.Large, PackagingType.Household, MaterialType.Plastic, MaterialSubType.Flexible,  DataSubmissionPeriodTestData.Year2026H1)]
+    public void Should_Fail_When_No_Rating_Supplied_For_Matching_MaterialTypes_During_2025H2_And_Beyond(string producerSize, string packagingType, string materialType, string materialSubType, string submissionPeriod)
+    {
+        var row = BuildProducerRow(
+            dataSubmissionPeriod: submissionPeriod,
+            producerType: ProducerType.SuppliedUnderYourBrand,
+            producerSize: producerSize,
+            packagingType: packagingType,
+            packagingClass: PackagingClass.PrimaryPackaging,
+            materialType: materialType,
+            materialSubType: materialSubType,
+            recyclabilityRating: string.Empty);
+
+        var result = _systemUnderTest.TestValidate(new ValidationContext<ProducerRow>(row));
+
+        result.ShouldHaveValidationErrorFor(x => x.RecyclabilityRating)
+            .WithErrorCode(ErrorCode.LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode);
+    }
+
+    [TestMethod]
+    [DataRow(ProducerSize.Large, PackagingType.HouseholdDrinksContainers, MaterialType.Glass, "", DataSubmissionPeriodTestData.Year2025H2)]
+    [DataRow(ProducerSize.Large, PackagingType.PublicBin, MaterialType.PaperCard, "", DataSubmissionPeriodTestData.Year2025H2)]
+    [DataRow(ProducerSize.Large, PackagingType.Household, MaterialType.Plastic, MaterialSubType.Rigid, DataSubmissionPeriodTestData.Year2025H2)]
+    [DataRow(ProducerSize.Large, PackagingType.Household, MaterialType.Plastic, MaterialSubType.Flexible,  DataSubmissionPeriodTestData.Year2025H2)]
+    [DataRow(ProducerSize.Large, PackagingType.HouseholdDrinksContainers, MaterialType.Glass, "", DataSubmissionPeriodTestData.Year2026H1)]
+    [DataRow(ProducerSize.Large, PackagingType.PublicBin, MaterialType.PaperCard, "", DataSubmissionPeriodTestData.Year2026H1)]
+    [DataRow(ProducerSize.Large, PackagingType.Household, MaterialType.Plastic, MaterialSubType.Rigid, DataSubmissionPeriodTestData.Year2026H1)]
+    [DataRow(ProducerSize.Large, PackagingType.Household, MaterialType.Plastic, MaterialSubType.Flexible,  DataSubmissionPeriodTestData.Year2026H1)]
+    public void Should_Pass_When_A_Recyclability_Rating_Supplied_For_Matching_MaterialTypes_During_2025H2_And_Beyond(string producerSize, string packagingType, string materialType, string materialSubType, string submissionPeriod)
+    {
+        var row = BuildProducerRow(
+            dataSubmissionPeriod: submissionPeriod,
+            producerType: ProducerType.SuppliedUnderYourBrand,
+            producerSize: producerSize,
+            packagingType: packagingType,
+            packagingClass: PackagingClass.PrimaryPackaging,
+            materialType: materialType,
+            materialSubType: materialSubType,
+            recyclabilityRating: RecyclabilityRating.Green);
+
+        var result = _systemUnderTest.TestValidate(new ValidationContext<ProducerRow>(row));
+
+        result.ShouldNotHaveAnyValidationErrors();
     }
 
     [TestMethod]
@@ -404,12 +468,5 @@ public class RecyclabilityRatingValidatorTests : RecyclabilityRatingValidator
     private static ProducerRow BuildProducerRow(string dataSubmissionPeriod, string producerType, string producerSize, string packagingType, string packagingClass, string materialType, string materialSubType, string recyclabilityRating)
     {
         return new ProducerRow(null, dataSubmissionPeriod, null, 1, producerType, producerSize, packagingType, packagingClass, materialType, materialSubType, null, null, null, null, null, null, recyclabilityRating);
-    }
-
-    private static ValidationContext<ProducerRow> CreateContextWithFeatureFlag(ProducerRow row, bool isEnabled = true)
-    {
-        var context = new ValidationContext<ProducerRow>(row);
-        context.RootContextData[FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation] = isEnabled;
-        return context;
     }
 }

--- a/src/EPR.ProducerContentValidation.Application/ConfigureServices.cs
+++ b/src/EPR.ProducerContentValidation.Application/ConfigureServices.cs
@@ -31,10 +31,13 @@ public static class ConfigureServices
 
     private static void RegisterServices(this IServiceCollection services)
     {
-        var redisOptions = services.BuildServiceProvider().GetRequiredService<IOptions<RedisOptions>>().Value;
         services
             .AddScoped<ISubmissionApiClient, SubmissionApiClient>()
-            .AddSingleton<IConnectionMultiplexer>(ConnectionMultiplexer.Connect(redisOptions.ConnectionString))
+            .AddSingleton<IConnectionMultiplexer>(sp =>
+            {
+                var redisOptions = sp.GetRequiredService<IOptions<RedisOptions>>().Value;
+                return ConnectionMultiplexer.Connect(redisOptions.ConnectionString);
+            })
             .AddSingleton<IIssueCountService, IssueCountService>()
             .AddSingleton<IRequestValidator, RequestValidator>()
             .AddSingleton<ISubsidiaryMatcher, SubsidiaryMatcher>()

--- a/src/EPR.ProducerContentValidation.Application/Constants/ErrorCode.cs
+++ b/src/EPR.ProducerContentValidation.Application/Constants/ErrorCode.cs
@@ -69,11 +69,9 @@ public static class ErrorCode
     public const string ClosedLoopRecyclingRecyclabilityRatingInvalidErrorCode = "918";
 
     /*Modulation - Recyclability rating error codes*/
-    public const string LargeProducerRecyclabilityRatingRequired = "100";
     public const string LargeProducerPlasticMaterialSubTypeRequired = "101";
     public const string LargeProducerRecyclabilityRatingNotRequired = "102";
     public const string LargeProducerPlasticMaterialSubTypeInvalidErrorCode = "103";
-    public const string LargeProducerRecyclabilityRatingInvalidErrorCode = "104";
     public const string SmallProducerPlasticMaterialSubTypeNotRequired = "105";
     public const string SmallProducerRecyclabilityRatingNotRequired = "106";
     public const string SmallProducerOnlyPlasticMaterialTypeAllowed = "107";

--- a/src/EPR.ProducerContentValidation.Application/Constants/ErrorCode.cs
+++ b/src/EPR.ProducerContentValidation.Application/Constants/ErrorCode.cs
@@ -69,13 +69,13 @@ public static class ErrorCode
     public const string ClosedLoopRecyclingRecyclabilityRatingInvalidErrorCode = "918";
 
     /*Modulation - Recyclability rating error codes*/
+    public const string LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode = "100";
     public const string LargeProducerPlasticMaterialSubTypeRequired = "101";
     public const string LargeProducerRecyclabilityRatingNotRequired = "102";
     public const string LargeProducerPlasticMaterialSubTypeInvalidErrorCode = "103";
     public const string SmallProducerPlasticMaterialSubTypeNotRequired = "105";
     public const string SmallProducerRecyclabilityRatingNotRequired = "106";
     public const string SmallProducerOnlyPlasticMaterialTypeAllowed = "107";
-    public const string LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode = "108";
     public const string LargeProducerInvalidForWasteAndMaterialType = "109";
 
     /* Issue codes for warnings */

--- a/src/EPR.ProducerContentValidation.Application/Constants/FeatureFlags.cs
+++ b/src/EPR.ProducerContentValidation.Application/Constants/FeatureFlags.cs
@@ -3,7 +3,5 @@
     public static class FeatureFlags
     {
         public const string EnableSubsidiaryValidationPom = "EnableSubsidiaryValidationPom";
-        public const string EnableLargeProducerRecyclabilityRatingValidation = "EnableLargeProducerRecyclabilityRatingValidation";
-        public const string EnableLargeProducerEnhancedRecyclabilityRatingValidation = "EnableLargeProducerEnhancedRecyclabilityRatingValidation";
     }
 }

--- a/src/EPR.ProducerContentValidation.Application/Validators/CompositeValidator.cs
+++ b/src/EPR.ProducerContentValidation.Application/Validators/CompositeValidator.cs
@@ -45,18 +45,12 @@ public class CompositeValidator : ICompositeValidator
 
     public async Task ValidateAndFetchForIssuesAsync(IEnumerable<ProducerRow> producerRows, List<ProducerValidationEventIssueRequest> errors, List<ProducerValidationEventIssueRequest> warnings, string blobName)
     {
-        var flag = await _featureManager.IsEnabledAsync(FeatureFlags.EnableLargeProducerRecyclabilityRatingValidation);
-        var enhancedProducerflag = await _featureManager.IsEnabledAsync(FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation);
         foreach (var row in producerRows)
         {
             var errorContext = new ValidationContext<ProducerRow>(row);
             var warningContext = new ValidationContext<ProducerRow>(row);
 
             errorContext.RootContextData.Add(SubmissionPeriodOption.Section, submissionOptions.Value);
-            errorContext.RootContextData.Add(FeatureFlags.EnableLargeProducerRecyclabilityRatingValidation, flag);
-            warningContext.RootContextData.Add(FeatureFlags.EnableLargeProducerRecyclabilityRatingValidation, flag);
-            errorContext.RootContextData.Add(FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation, enhancedProducerflag);
-            warningContext.RootContextData.Add(FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation, enhancedProducerflag);
             warningContext.RootContextData.Add(SubmissionPeriodOption.Section, submissionOptions.Value);
 
             await ValidateIssue(row, errors, blobName, IssueType.Error, errorContext);

--- a/src/EPR.ProducerContentValidation.Application/Validators/CompositeValidator.cs
+++ b/src/EPR.ProducerContentValidation.Application/Validators/CompositeValidator.cs
@@ -8,7 +8,6 @@ using EPR.ProducerContentValidation.Application.Validators.Factories.Interfaces;
 using EPR.ProducerContentValidation.Application.Validators.Interfaces;
 using FluentValidation;
 using Microsoft.Extensions.Options;
-using Microsoft.FeatureManagement;
 
 namespace EPR.ProducerContentValidation.Application.Validators;
 
@@ -18,25 +17,22 @@ public class CompositeValidator : ICompositeValidator
     private readonly IValidator<ProducerRow> _producerRowWarningValidator;
     private readonly IGroupedValidator _groupedValidator;
     private readonly IDuplicateValidator _duplicateValidator;
-    private readonly IOptions<List<SubmissionPeriodOption>> submissionOptions;
+    private readonly IOptions<List<SubmissionPeriodOption>> _submissionOptions;
     private readonly IIssueCountService _issueCountService;
     private readonly ValidationOptions _validationOptions;
-    private readonly IFeatureManager _featureManager;
 
     public CompositeValidator(
         IOptions<ValidationOptions> validationOptions,
         IOptions<List<SubmissionPeriodOption>> submissionOptions,
-        IFeatureManager featureManager,
         IIssueCountService issueCountService,
         IProducerRowValidatorFactory producerRowValidatorFactory,
         IProducerRowWarningValidatorFactory producerRowWarningValidatorFactory,
         IGroupedValidator groupedValidator,
         IDuplicateValidator duplicateValidator)
     {
-        this.submissionOptions = submissionOptions;
+        _submissionOptions = submissionOptions;
         _issueCountService = issueCountService;
         _validationOptions = validationOptions.Value;
-        _featureManager = featureManager;
         _producerRowValidator = producerRowValidatorFactory.GetInstance();
         _producerRowWarningValidator = producerRowWarningValidatorFactory.GetInstance();
         _groupedValidator = groupedValidator;
@@ -50,8 +46,8 @@ public class CompositeValidator : ICompositeValidator
             var errorContext = new ValidationContext<ProducerRow>(row);
             var warningContext = new ValidationContext<ProducerRow>(row);
 
-            errorContext.RootContextData.Add(SubmissionPeriodOption.Section, submissionOptions.Value);
-            warningContext.RootContextData.Add(SubmissionPeriodOption.Section, submissionOptions.Value);
+            errorContext.RootContextData.Add(SubmissionPeriodOption.Section, _submissionOptions.Value);
+            warningContext.RootContextData.Add(SubmissionPeriodOption.Section, _submissionOptions.Value);
 
             await ValidateIssue(row, errors, blobName, IssueType.Error, errorContext);
 

--- a/src/EPR.ProducerContentValidation.Application/Validators/ProducerRowValidator.cs
+++ b/src/EPR.ProducerContentValidation.Application/Validators/ProducerRowValidator.cs
@@ -58,11 +58,7 @@ public class ProducerRowValidator : AbstractValidator<ProducerRow>
         Include(new TransitionalPackagingUnitsValidator());
 
         Include(new SmallProducerPackagingTypeValidator());
-
-        if (featureManager.IsEnabledAsync(FeatureFlags.EnableLargeProducerRecyclabilityRatingValidation).Result)
-        {
-            Include(new RecyclabilityRatingValidator()); // large producer only
-        }
+        Include(new RecyclabilityRatingValidator()); // large producer only
     }
 
     protected override bool PreValidate(ValidationContext<ProducerRow> context, ValidationResult result)

--- a/src/EPR.ProducerContentValidation.Application/Validators/PropertyValidators/ClosedLoopRecyclingRecyclabilityRatingValidator.cs
+++ b/src/EPR.ProducerContentValidation.Application/Validators/PropertyValidators/ClosedLoopRecyclingRecyclabilityRatingValidator.cs
@@ -17,7 +17,7 @@ public class ClosedLoopRecyclingRecyclabilityRatingValidator : AbstractValidator
     public ClosedLoopRecyclingRecyclabilityRatingValidator()
     {
         RuleFor(x => x.RecyclabilityRating)
-            .Null()
+            .Empty() // SUB-271, altered this to "Empty" instead of "Null" as part of wider fix. An empty string should not trigger this rule.
             .WithErrorCode(ErrorCode.ClosedLoopRecyclingRecyclabilityRatingInvalidErrorCode);
     }
 

--- a/src/EPR.ProducerContentValidation.Application/Validators/PropertyValidators/RecyclabilityRatingValidator.cs
+++ b/src/EPR.ProducerContentValidation.Application/Validators/PropertyValidators/RecyclabilityRatingValidator.cs
@@ -1,12 +1,12 @@
 ﻿namespace EPR.ProducerContentValidation.Application.Validators.PropertyValidators;
 
 using Constants;
-using EPR.ProducerContentValidation.Application.ReferenceData;
-using EPR.ProducerContentValidation.Application.Validators.CustomValidators;
-using EPR.ProducerContentValidation.Application.Validators.HelperFunctions;
+using CustomValidators;
 using FluentValidation;
 using FluentValidation.Results;
+using HelperFunctions;
 using Models;
+using ReferenceData;
 
 public class RecyclabilityRatingValidator : AbstractValidator<ProducerRow>
 {
@@ -16,50 +16,39 @@ public class RecyclabilityRatingValidator : AbstractValidator<ProducerRow>
         RuleFor(x => x.RecyclabilityRating)
             .IsInAllowedValues(ReferenceDataGenerator.RecyclabilityRatings)
             .WithErrorCode(ErrorCode.LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode)
-            .When((row, ctx) =>
-                HelperFunctions.IsFeatureFlagOn(ctx, FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation)
-                && !string.IsNullOrEmpty(row.RecyclabilityRating)
-                && IsLargeProducerRecyclabilityRatingApplicable(row));
-
-        // Invalid if provided rating is not in allowed values — default version
-        RuleFor(x => x.RecyclabilityRating)
-            .IsInAllowedValues(ReferenceDataGenerator.RecyclabilityRatings)
-            .WithErrorCode(ErrorCode.LargeProducerRecyclabilityRatingInvalidErrorCode)
-            .When((row, ctx) =>
-                !HelperFunctions.IsFeatureFlagOn(ctx, FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation)
-                && !string.IsNullOrEmpty(row.RecyclabilityRating)
+            .When((row, _) =>
+                !string.IsNullOrEmpty(row.RecyclabilityRating)
                 && IsLargeProducerRecyclabilityRatingApplicable(row));
 
         // Disallow rating before 2025
         RuleFor(x => x.RecyclabilityRating)
             .Empty()
             .WithErrorCode(ErrorCode.LargeProducerRecyclabilityRatingNotRequired)
-            .When(x => IsLargeProducerRecyclabilityRatingNotRequiredBefore2025(x));
+            .When(IsLargeProducerRecyclabilityRatingNotRequiredBefore2025);
+
+        // Require rating from 2025-H2 onwards for applicable combinations (2025-H1 remains optional)
+        RuleFor(x => x.RecyclabilityRating)
+            .NotEmpty()
+            .WithErrorCode(ErrorCode.LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode)
+            .When((row, _) =>
+                string.IsNullOrEmpty(row.RecyclabilityRating)
+                && !Is2025H1(row.DataSubmissionPeriod)
+                && IsLargeProducerRecyclabilityRatingApplicable(row));
 
         // Disallow rating for small producers for any submission year
         RuleFor(x => x.RecyclabilityRating)
             .Empty()
             .WithErrorCode(ErrorCode.SmallProducerRecyclabilityRatingNotRequired)
-               .When((row, ctx) =>
+               .When((row, _) =>
                         ProducerSize.Small.Equals(row.ProducerSize, StringComparison.OrdinalIgnoreCase)
-                        && (!string.IsNullOrWhiteSpace(row.RecyclabilityRating)));
-
-        // Rating is required only if feature flag is OFF
-        RuleFor(x => x.RecyclabilityRating)
-            .NotEmpty()
-            .WithErrorCode(ErrorCode.LargeProducerRecyclabilityRatingRequired)
-            .When((row, ctx) =>
-                !HelperFunctions.IsFeatureFlagOn(ctx, FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation)
-                && string.IsNullOrEmpty(row.RecyclabilityRating)
-                && IsLargeProducerRecyclabilityRatingApplicable(row));
+                        && !string.IsNullOrWhiteSpace(row.RecyclabilityRating));
 
         // Disallow rating for invalid packaging types (e.g., CW, OW, HDC with non-glass)
         RuleFor(x => x.RecyclabilityRating)
             .Empty()
             .WithErrorCode(ErrorCode.LargeProducerInvalidForWasteAndMaterialType)
-            .When((row, ctx) =>
-                HelperFunctions.IsFeatureFlagOn(ctx, FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation)
-                && ProducerSize.Large.Equals(row.ProducerSize, StringComparison.OrdinalIgnoreCase)
+            .When((row, _) =>
+                ProducerSize.Large.Equals(row.ProducerSize, StringComparison.OrdinalIgnoreCase)
                 && !IsLargeProducerWithValidWasteAndMaterialType(row)
                 && !string.IsNullOrWhiteSpace(row.RecyclabilityRating));
     }
@@ -70,8 +59,26 @@ public class RecyclabilityRatingValidator : AbstractValidator<ProducerRow>
         return !PackagingType.ClosedLoopRecycling.Equals(producerRow.WasteType);
     }
 
+    private static bool Is2025H1(string? dataSubmissionPeriod)
+    {
+        return "2025-H1".Equals(dataSubmissionPeriod, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static bool IsLargeProducerRecyclabilityRatingApplicable(ProducerRow row)
     {
+        if (!ProducerSize.Large.Equals(row.ProducerSize, StringComparison.OrdinalIgnoreCase)
+            || HelperFunctions.IsSubmissionPeriodBeforeYear(row.DataSubmissionPeriod, 2025))
+        {
+            return false;
+        }
+
+        // HDC + Glass is rated regardless of subtype or packaging category
+        if (PackagingType.HouseholdDrinksContainers.Equals(row.WasteType, StringComparison.OrdinalIgnoreCase)
+            && MaterialType.Glass.Equals(row.MaterialType, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
         return HelperFunctions.ShouldApply2025HouseholdRulesForLargeProducerFor2025AndBeyond(
             row.ProducerSize, row.WasteType, row.PackagingCategory, row.DataSubmissionPeriod)
             && (
@@ -104,11 +111,11 @@ public class RecyclabilityRatingValidator : AbstractValidator<ProducerRow>
         var packagingType = row.WasteType;
         var materialType = row.MaterialType;
 
-        bool isHdcGlass =
+        var isHdcGlass =
             PackagingType.HouseholdDrinksContainers.Equals(packagingType, StringComparison.OrdinalIgnoreCase)
             && MaterialType.Glass.Equals(materialType, StringComparison.OrdinalIgnoreCase);
 
-        bool isHhOrPb =
+        var isHhOrPb =
             PackagingType.Household.Equals(packagingType, StringComparison.OrdinalIgnoreCase) ||
             PackagingType.PublicBin.Equals(packagingType, StringComparison.OrdinalIgnoreCase);
 

--- a/src/EPR.ProducerContentValidation.FunctionApp/settings.json
+++ b/src/EPR.ProducerContentValidation.FunctionApp/settings.json
@@ -14,7 +14,6 @@
     "Redis:ConnectionString": "https://localhost:1234",
     "Validation:IsLatest": true,
     "HttpEndpoint:Enabled": false,
-    "FeatureManagement:EnableSubsidiaryValidationPom": false,
-    "FeatureManagement:EnableLargeProducerRecyclabilityRatingValidation": false
+    "FeatureManagement:EnableSubsidiaryValidationPom": false
   }
 }

--- a/src/EPR.ProducerContentValidation.IntegrationTests/README.md
+++ b/src/EPR.ProducerContentValidation.IntegrationTests/README.md
@@ -13,11 +13,6 @@ Integration tests for the **validate-producer-content** HTTP endpoint. They send
 2. **Submission period configuration**  
    Some tests expect valid data submission periods (e.g. `2026-P1`, `January to June 2026`). Ensure the function app’s `SubmissionPeriods` configuration includes the periods used in the tests, or those tests may report different errors (e.g. 44).
 
-3. **Feature flags (for full coverage)**  
-   Tests assume the following feature flags are **enabled** in the function app (`local.settings.json` or `settings.json`):
-   - `FeatureManagement:EnableLargeProducerRecyclabilityRatingValidation` = `true` — recyclability tests (102, 106, 108, 109)
-   - `FeatureManagement:EnableLargeProducerEnhancedRecyclabilityRatingValidation` = `true` — enhanced recyclability (108, 109)
-   
    With these set, all feature-flagged API tests will pass.
 
 ## Running the integration tests

--- a/src/EPR.ProducerContentValidation.IntegrationTests/RecyclabilityAndMaterialSubTypeApiTests.cs
+++ b/src/EPR.ProducerContentValidation.IntegrationTests/RecyclabilityAndMaterialSubTypeApiTests.cs
@@ -7,9 +7,6 @@ namespace EPR.ProducerContentValidation.IntegrationTests;
 
 /// <summary>
 /// API tests for recyclability rating (100-109) and material/subtype validators (45, 47, 51, etc.).
-/// Recyclability and small-producer-enhanced tests assume feature flags are enabled in the function app:
-/// - EnableLargeProducerRecyclabilityRatingValidation (for 100, 102, 104, 106, 108, 109)
-/// - EnableLargeProducerEnhancedRecyclabilityRatingValidation (for 108, 109).
 /// </summary>
 [Collection("ValidateProducerContentApi")]
 [Trait("Category", "IntegrationTest")]
@@ -63,7 +60,7 @@ public class RecyclabilityAndMaterialSubTypeApiTests : ValidateProducerContentAp
 
         result.IsSuccess.Should().BeTrue();
         result.HasErrorCode(ErrorCode.SmallProducerRecyclabilityRatingNotRequired).Should().BeTrue(
-            "Requires EnableLargeProducerRecyclabilityRatingValidation = true. Small producers must not supply a recyclability rating.");
+            "Small producers must not supply a recyclability rating.");
     }
 
     [Fact]
@@ -114,7 +111,6 @@ public class RecyclabilityAndMaterialSubTypeApiTests : ValidateProducerContentAp
         result.HasErrorCode(ErrorCode.SmallProducerPlasticMaterialSubTypeNotRequired).Should().BeTrue();
     }
 
-    /* Recyclability: assume EnableLargeProducerRecyclabilityRatingValidation = true */
     [Fact]
     public async Task Large_producer_2024_with_recyclability_rating_returns_error_102()
     {
@@ -130,11 +126,11 @@ public class RecyclabilityAndMaterialSubTypeApiTests : ValidateProducerContentAp
 
         result.IsSuccess.Should().BeTrue();
         result.HasErrorCode(ErrorCode.LargeProducerRecyclabilityRatingNotRequired).Should().BeTrue(
-            "Requires EnableLargeProducerRecyclabilityRatingValidation = true. Rating not required before 2025.");
+            "Rating not required before 2025.");
     }
 
     [Fact]
-    public async Task Large_producer_invalid_recyclability_value_returns_error_108()
+    public async Task Large_producer_invalid_recyclability_value_returns_error_100()
     {
         var request = ValidateProducerContentRequestBuilder.ValidRequest();
         request.Rows[0] = ValidateProducerContentRequestBuilder.ValidRow(
@@ -146,7 +142,7 @@ public class RecyclabilityAndMaterialSubTypeApiTests : ValidateProducerContentAp
 
         result.IsSuccess.Should().BeTrue();
         result.HasErrorCode(ErrorCode.LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode).Should().BeTrue(
-                "Requires EnableLargeProducerRecyclabilityRatingValidation = true. Invalid rating gives 108 (enhanced).");
+                "Invalid rating gives 100 (enhanced).");
     }
 
     [Fact]
@@ -164,7 +160,7 @@ public class RecyclabilityAndMaterialSubTypeApiTests : ValidateProducerContentAp
 
         result.IsSuccess.Should().BeTrue();
         result.HasErrorCode(ErrorCode.LargeProducerInvalidForWasteAndMaterialType).Should().BeTrue(
-            "Requires EnableLargeProducerRecyclabilityRatingValidation and EnableLargeProducerEnhancedRecyclabilityRatingValidation = true. CW/OW/HDC non-glass must not have rating.");
+            "CW/OW/HDC non-glass must not have rating.");
     }
 
     // Error 100 (LargeProducerRecyclabilityRatingRequired) only runs when EnableLargeProducerEnhancedRecyclabilityRatingValidation = false.

--- a/src/EPR.ProducerContentValidation.IntegrationTests/RecyclabilityAndMaterialSubTypeApiTests.cs
+++ b/src/EPR.ProducerContentValidation.IntegrationTests/RecyclabilityAndMaterialSubTypeApiTests.cs
@@ -9,7 +9,7 @@ namespace EPR.ProducerContentValidation.IntegrationTests;
 /// API tests for recyclability rating (100-109) and material/subtype validators (45, 47, 51, etc.).
 /// Recyclability and small-producer-enhanced tests assume feature flags are enabled in the function app:
 /// - EnableLargeProducerRecyclabilityRatingValidation (for 100, 102, 104, 106, 108, 109)
-/// - EnableLargeProducerEnhancedRecyclabilityRatingValidation (for 108, 109)
+/// - EnableLargeProducerEnhancedRecyclabilityRatingValidation (for 108, 109).
 /// </summary>
 [Collection("ValidateProducerContentApi")]
 [Trait("Category", "IntegrationTest")]
@@ -134,7 +134,7 @@ public class RecyclabilityAndMaterialSubTypeApiTests : ValidateProducerContentAp
     }
 
     [Fact]
-    public async Task Large_producer_invalid_recyclability_value_returns_error_104_or_108()
+    public async Task Large_producer_invalid_recyclability_value_returns_error_108()
     {
         var request = ValidateProducerContentRequestBuilder.ValidRequest();
         request.Rows[0] = ValidateProducerContentRequestBuilder.ValidRow(
@@ -145,10 +145,8 @@ public class RecyclabilityAndMaterialSubTypeApiTests : ValidateProducerContentAp
         var result = await ValidateAndLogAsync(request);
 
         result.IsSuccess.Should().BeTrue();
-        (result.HasErrorCode(ErrorCode.LargeProducerRecyclabilityRatingInvalidErrorCode)
-            || result.HasErrorCode(ErrorCode.LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode))
-            .Should().BeTrue(
-                "Requires EnableLargeProducerRecyclabilityRatingValidation = true. Invalid rating gives 104 (default) or 108 (enhanced).");
+        result.HasErrorCode(ErrorCode.LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode).Should().BeTrue(
+                "Requires EnableLargeProducerRecyclabilityRatingValidation = true. Invalid rating gives 108 (enhanced).");
     }
 
     [Fact]

--- a/src/EPR.ProducerContentValidation.TestSupport/InProcessValidationHarness.cs
+++ b/src/EPR.ProducerContentValidation.TestSupport/InProcessValidationHarness.cs
@@ -48,9 +48,6 @@ public static class InProcessValidationHarness
         featureManagerMock.Setup(x => x.IsEnabledAsync(FeatureFlags.EnableSubsidiaryValidationPom)).ReturnsAsync(false);
 
         // Align with typical local Functions config: recyclability rules off unless explicitly enabled in host.
-        featureManagerMock.Setup(x => x.IsEnabledAsync(FeatureFlags.EnableLargeProducerRecyclabilityRatingValidation)).ReturnsAsync(false);
-        featureManagerMock.Setup(x => x.IsEnabledAsync(FeatureFlags.EnableLargeProducerEnhancedRecyclabilityRatingValidation)).ReturnsAsync(false);
-
         var submissionPeriodOptions = Options.Create(LoadSubmissionPeriods());
 
         var producerRowValidatorFactory = new ProducerRowValidatorFactory(validationOptionsMock.Object, featureManagerMock.Object);

--- a/src/EPR.ProducerContentValidation.TestSupport/InProcessValidationHarness.cs
+++ b/src/EPR.ProducerContentValidation.TestSupport/InProcessValidationHarness.cs
@@ -58,7 +58,6 @@ public static class InProcessValidationHarness
         var compositeValidator = new CompositeValidator(
             validationOptionsMock.Object,
             submissionPeriodOptions,
-            featureManagerMock.Object,
             issueCountServiceMock.Object,
             producerRowValidatorFactory,
             producerRowWarningValidatorFactory,


### PR DESCRIPTION
SUB-271: Plug hole in RAM-RAG rating validation by removing feature flags and requiring a rating from 2025-H2 onwards
Removed the EnableLargeProducerRecyclabilityRatingValidation and
EnableLargeProducerEnhancedRecyclabilityRatingValidation feature flags
together with the obsolete "default" (pre-enhanced) error codes 100 and
104. The enhanced rules are now the only path, always on.

Plugged the missing rule that the flag removal exposed: for large
producers from 2025-H2 onwards, an empty RecyclabilityRating on an
applicable waste/material combination now fails with error 108
(LargeProducerEnhancedRecyclabilityRatingValidationInvalidErrorCode).
2025-H1 remains optional.

Also relaxed ClosedLoopRecyclingRecyclabilityRatingValidator from Null()
to Empty() so an empty string does not spuriously trigger 918, and
cleaned up flag plumbing in CompositeValidator, ProducerRowValidator,
InProcessValidationHarness, and the affected unit / integration tests.