### PR TITLE
Feature/sub 276 upgrade to dotnet10

### DIFF
--- a/pipelines/ci_pipeline.yaml
+++ b/pipelines/ci_pipeline.yaml
@@ -20,7 +20,7 @@ parameters:
     type: boolean
     default: true
     
-pool: DEFRA-COMMON-ubuntu2004-SSV3
+pool: DEFRA-COMMON-UBUNTU-SSV3
 
 variables:
   - template: vars/DEV4-development.yaml
@@ -39,7 +39,7 @@ variables:
   - name: runTests
     value: true
   - name: dotnetVersion
-    value: dotnetVersion8
+    value: dotnetVersion10
 
 resources:
   repositories:
@@ -65,6 +65,6 @@ extends:
     branchName: ${{ replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), '/', '_') }}
     runNugetTasks: ${{ variables.runNugetTasks }}
     serviceName: $(serviceName)
-    dotnetVersion: ${{ variables.dotnetVersion8 }}
+    dotnetVersion: ${{ variables.dotnetVersion10 }}
     sonarqubeInstance: ${{ parameters.sonarqubeInstance }}
 

--- a/pipelines/ci_pipeline.yaml
+++ b/pipelines/ci_pipeline.yaml
@@ -65,6 +65,6 @@ extends:
     branchName: ${{ replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), '/', '_') }}
     runNugetTasks: ${{ variables.runNugetTasks }}
     serviceName: $(serviceName)
-    dotnetVersion: ${{ variables.dotnetVersion10 }}
+    dotnetVersion: ${{ variables.dotnetVersion }}
     sonarqubeInstance: ${{ parameters.sonarqubeInstance }}
 

--- a/pipelines/deployment-pipeline.yaml
+++ b/pipelines/deployment-pipeline.yaml
@@ -1,6 +1,6 @@
 trigger: none
 pr: none
-pool: DEFRA-COMMON-ubuntu2004-SSV3
+pool: DEFRA-COMMON-UBUNTU-SSV3
 
 appendCommitMessageToRunName: false
 name: 'Deploy code to $(serviceName)'

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <CodeAnalysisRuleSet>..\stylecop.ruleset</CodeAnalysisRuleSet>

--- a/src/EPR.ProducerContentValidation.Application.UnitTests/EPR.ProducerContentValidation.Application.UnitTests.csproj
+++ b/src/EPR.ProducerContentValidation.Application.UnitTests/EPR.ProducerContentValidation.Application.UnitTests.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <IsPackable>false</IsPackable>
         <SonarQubeTestProject>true</SonarQubeTestProject>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
 		<NoWarn>CA1859</NoWarn>
     </PropertyGroup>
 
@@ -23,8 +23,6 @@
         <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
         <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
-        <PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/EPR.ProducerContentValidation.Application/EPR.ProducerContentValidation.Application.csproj
+++ b/src/EPR.ProducerContentValidation.Application/EPR.ProducerContentValidation.Application.csproj
@@ -1,25 +1,25 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <SonarQubeTestProject>false</SonarQubeTestProject>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
 		<NoWarn>S107;CA1859</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-<PackageReference Include="Azure.Core" Version="1.44.1" />
-        <PackageReference Include="Azure.Identity" Version="1.13.1" />
+<PackageReference Include="Azure.Core" Version="1.47.3" />
+        <PackageReference Include="Azure.Identity" Version="1.16.0" />
         <PackageReference Include="FluentValidation" Version="11.9.2" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-        <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.5.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
+        <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="StackExchange.Redis" Version="2.8.0" />
     </ItemGroup>

--- a/src/EPR.ProducerContentValidation.FunctionApp.UnitTests/EPR.ProducerContentValidation.FunctionApp.UnitTests.csproj
+++ b/src/EPR.ProducerContentValidation.FunctionApp.UnitTests/EPR.ProducerContentValidation.FunctionApp.UnitTests.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <IsPackable>false</IsPackable>
         <SonarQubeTestProject>true</SonarQubeTestProject>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -16,7 +16,7 @@
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="ILogger.Moq" Version="1.1.10" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
         <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />

--- a/src/EPR.ProducerContentValidation.FunctionApp/Dockerfile
+++ b/src/EPR.ProducerContentValidation.FunctionApp/Dockerfile
@@ -1,5 +1,5 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS installer-env
-# FROM defradigital/dotnetcore-development:dotnet8.0 AS installer-env
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS installer-env
+# FROM defradigital/dotnetcore-development:dotnet10.0 AS installer-env
 
 # Build requires 3.1 SDK
 #COPY --from=mcr.microsoft.com/dotnet/core/sdk:3.1 /usr/share/dotnet /usr/share/dotnet
@@ -12,7 +12,7 @@ COPY EPR.ProducerContentValidation.FunctionApp/. ./EPR.ProducerContentValidation
 
 RUN dotnet publish EPR.ProducerContentValidation.FunctionApp/*.csproj --output /home/site/wwwroot
 
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated10.0
 
 # Create a non-root user and set permissions
 RUN groupadd -r dotnet && \

--- a/src/EPR.ProducerContentValidation.FunctionApp/EPR.ProducerContentValidation.FunctionApp.csproj
+++ b/src/EPR.ProducerContentValidation.FunctionApp/EPR.ProducerContentValidation.FunctionApp.csproj
@@ -1,24 +1,24 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <AzureFunctionsVersion>v4</AzureFunctionsVersion>
         <OutputType>Exe</OutputType>
         <SonarQubeTestProject>false</SonarQubeTestProject>
         <UserSecretsId>f5649d0b-74d7-4319-aa6e-87a78c16fe14</UserSecretsId>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.13.1" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.15.0" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
+        <PackageReference Include="Azure.Identity" Version="1.16.0" />
+        <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.24.0" />
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
         <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-        <PackageReference Include="System.Drawing.Common" Version="8.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
+        <PackageReference Include="System.Drawing.Common" Version="10.0.0" />
     </ItemGroup>
     <ItemGroup>
         <None Update="host.json">

--- a/src/EPR.ProducerContentValidation.IntegrationTests/EPR.ProducerContentValidation.IntegrationTests.csproj
+++ b/src/EPR.ProducerContentValidation.IntegrationTests/EPR.ProducerContentValidation.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/EPR.ProducerContentValidation.TestSupport/EPR.ProducerContentValidation.TestSupport.csproj
+++ b/src/EPR.ProducerContentValidation.TestSupport/EPR.ProducerContentValidation.TestSupport.csproj
@@ -13,6 +13,6 @@
 
   <PropertyGroup>
     <SonarQubeExclude>true</SonarQubeExclude>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/EPR.ProducerContentValidation.TestSupport/InputCsvRegressionRowLoader.cs
+++ b/src/EPR.ProducerContentValidation.TestSupport/InputCsvRegressionRowLoader.cs
@@ -35,7 +35,7 @@ public static class InputCsvRegressionRowLoader
 
     /// <summary>
     /// Resolves <c>real_pom_file_data.csv</c>: first next to the test assembly (build output), then the project directory
-    /// when resolving from typical <c>bin/.../net8.0</c> paths (three levels up).
+    /// when resolving from typical <c>bin/.../net10.0</c> paths (three levels up).
     /// </summary>
     public static string ResolveDefaultInputCsvPath()
     {

--- a/src/EPR.ProducerContentValidation.UnitTest/EPR.ProducerContentValidation.UnitTest.csproj
+++ b/src/EPR.ProducerContentValidation.UnitTest/EPR.ProducerContentValidation.UnitTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
- Bump all project target frameworks from net8.0 to net10.0 (Directory.Build.props + per-project csproj overrides).
- Bump Azure Functions worker stack: Microsoft.Azure.Functions.Worker 1.23.0 -> 2.2.0, Worker.Sdk 1.18.1 -> 2.0.7, Extensions.Http 3.2.0 -> 3.3.0, Extensions.ServiceBus 5.15.0 -> 5.24.0.
- Bump Microsoft.Extensions.* packages to 10.0.0, Azure.Identity to 1.16.0, Azure.Core to 1.47.3, System.Drawing.Common to 10.0.0, Microsoft.FeatureManagement.AspNetCore to 4.0.0.
- Switch Dockerfile base images to mcr.microsoft.com/dotnet/sdk:10.0 and mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated10.0.
- Update CI pipeline dotnetVersion variable to dotnetVersion10 and switch build/deploy pool from DEFRA-COMMON-ubuntu2004-SSV3 to DEFRA-COMMON-UBUNTU-SSV3.
- Remove redundant System.Net.Http and System.Text.RegularExpressions references from Application.UnitTests now that .NET 10 prunes them.