### PR TITLE
Bug/sub 271 correct the grouped validator to identify all failing rows

### DIFF
--- a/src/EPR.ProducerContentValidation.Application.UnitTests/Validators/GroupedValidators/ErrorValidators/PartialRecyclabilityRatingSubmissionGroupedValidatorTests.cs
+++ b/src/EPR.ProducerContentValidation.Application.UnitTests/Validators/GroupedValidators/ErrorValidators/PartialRecyclabilityRatingSubmissionGroupedValidatorTests.cs
@@ -42,15 +42,16 @@ public class PartialRecyclabilityRatingSubmissionGroupedValidatorTests
         var rows = new List<ProducerRow>
         {
             BuildProducerRow(packagingType: PackagingType.Household, materialType: MaterialType.Plastic, recyclabilityRating: string.Empty),
-            BuildProducerRow(packagingType: PackagingType.PublicBin, materialType: MaterialType.PaperCard, recyclabilityRating: RecyclabilityRating.Green)
+            BuildProducerRow(packagingType: PackagingType.PublicBin, materialType: MaterialType.PaperCard, recyclabilityRating: RecyclabilityRating.Green),
+            BuildProducerRow(packagingType: PackagingType.Household, materialType: MaterialType.Plastic, recyclabilityRating: string.Empty),
         };
 
         await _systemUnderTest.ValidateAsync(rows, StoreKey, BlobName, errors, warnings);
 
-        errors.Should().HaveCount(1);
+        errors.Should().HaveCount(2);
         errors.First().ErrorCodes.Should().ContainSingle(ErrorCode.LargeProducerRecyclabilityPartiallySupplied);
         warnings.Should().BeEmpty();
-        _issueCountServiceMock.Verify(x => x.IncrementIssueCountAsync(StoreKey, 1), Times.Once);
+        _issueCountServiceMock.Verify(x => x.IncrementIssueCountAsync(StoreKey, 1), Times.Exactly(2));
     }
 
     [TestMethod]
@@ -79,14 +80,16 @@ public class PartialRecyclabilityRatingSubmissionGroupedValidatorTests
         var rows = new List<ProducerRow>
         {
             BuildProducerRow(packagingType: PackagingType.HouseholdDrinksContainers, materialType: MaterialType.Glass, materialSubType: string.Empty, recyclabilityRating: string.Empty),
-            BuildProducerRow(packagingType: PackagingType.HouseholdDrinksContainers, materialType: MaterialType.Glass, materialSubType: string.Empty, recyclabilityRating: RecyclabilityRating.Amber)
+            BuildProducerRow(packagingType: PackagingType.HouseholdDrinksContainers, materialType: MaterialType.Glass, materialSubType: string.Empty, recyclabilityRating: RecyclabilityRating.Amber),
+            BuildProducerRow(packagingType: PackagingType.HouseholdDrinksContainers, materialType: MaterialType.Glass, materialSubType: string.Empty, recyclabilityRating: string.Empty),
         };
 
         await _systemUnderTest.ValidateAsync(rows, StoreKey, BlobName, errors, warnings);
 
-        errors.Should().HaveCount(1);
+        errors.Should().HaveCount(2);
         errors.First().ErrorCodes.Should().ContainSingle(ErrorCode.LargeProducerRecyclabilityPartiallySupplied);
         warnings.Should().BeEmpty();
+        _issueCountServiceMock.Verify(x => x.IncrementIssueCountAsync(StoreKey, 1), Times.Exactly(2));
     }
 
     [TestMethod]

--- a/src/EPR.ProducerContentValidation.Application.UnitTests/Validators/GroupedValidators/WarningValidators/RecyclabilityRatingMissingEntirelyGroupedValidatorTests.cs
+++ b/src/EPR.ProducerContentValidation.Application.UnitTests/Validators/GroupedValidators/WarningValidators/RecyclabilityRatingMissingEntirelyGroupedValidatorTests.cs
@@ -48,10 +48,10 @@ public class RecyclabilityRatingMissingEntirelyGroupedValidatorTests
 
         await _systemUnderTest.ValidateAsync(rows, StoreKey, BlobName, errors, warnings);
 
-        warnings.Should().HaveCount(1);
+        warnings.Should().HaveCount(3);
         warnings.First().ErrorCodes.Should().ContainSingle(ErrorCode.LargeProducerRecyclabilityMissing);
         errors.Should().BeEmpty();
-        _issueCountServiceMock.Verify(x => x.IncrementIssueCountAsync(StoreKey, 1), Times.Once);
+        _issueCountServiceMock.Verify(x => x.IncrementIssueCountAsync(StoreKey, 1), Times.Exactly(3));
     }
 
     [TestMethod]
@@ -142,10 +142,10 @@ public class RecyclabilityRatingMissingEntirelyGroupedValidatorTests
 
         await _systemUnderTest.ValidateAsync(rows, StoreKey, BlobName, errors, warnings);
 
-        warnings.Should().HaveCount(1);
+        warnings.Should().HaveCount(3);
         warnings.First().ErrorCodes.Should().ContainSingle(ErrorCode.LargeProducerRecyclabilityMissing);
         errors.Should().BeEmpty();
-        _issueCountServiceMock.Verify(x => x.IncrementIssueCountAsync(StoreKey, 1), Times.Once);
+        _issueCountServiceMock.Verify(x => x.IncrementIssueCountAsync(StoreKey, 1), Times.Exactly(3));
     }
 
     [TestMethod]

--- a/src/EPR.ProducerContentValidation.Application/Validators/GroupedValidators/ErrorValidators/PartialRecyclabilityRatingSubmissionGroupedValidator.cs
+++ b/src/EPR.ProducerContentValidation.Application/Validators/GroupedValidators/ErrorValidators/PartialRecyclabilityRatingSubmissionGroupedValidator.cs
@@ -33,12 +33,15 @@ public class PartialRecyclabilityRatingSubmissionGroupedValidator(IIssueCountSer
             return;
         }
 
-        var hasEmpty = matchingRows.Any(r => string.IsNullOrWhiteSpace(r.RecyclabilityRating));
-        var hasSupplied = matchingRows.Any(r => !string.IsNullOrWhiteSpace(r.RecyclabilityRating));
+        var emptyRows = matchingRows.Where(r => string.IsNullOrWhiteSpace(r.RecyclabilityRating)).ToList();
 
-        if (hasEmpty && hasSupplied)
+        if (emptyRows.Count > 0 && emptyRows.Count < matchingRows.Count)
         {
-            await FindAndAddErrorAsync(matchingRows[0], storeKey, errorRows, ErrorCode.LargeProducerRecyclabilityPartiallySupplied, blobName);
+            foreach (var emptyRow in emptyRows.TakeWhile(_ => remainingErrorCount > 0))
+            {
+                await FindAndAddErrorAsync(emptyRow, storeKey, errorRows, ErrorCode.LargeProducerRecyclabilityPartiallySupplied, blobName);
+                remainingErrorCount = await _issueCountService.GetRemainingIssueCapacityAsync(storeKey);
+            }
         }
     }
 }

--- a/src/EPR.ProducerContentValidation.Application/Validators/GroupedValidators/WarningValidators/RecyclabilityRatingMissingEntirelyGroupedValidator.cs
+++ b/src/EPR.ProducerContentValidation.Application/Validators/GroupedValidators/WarningValidators/RecyclabilityRatingMissingEntirelyGroupedValidator.cs
@@ -35,7 +35,11 @@ public class RecyclabilityRatingMissingEntirelyGroupedValidator(IIssueCountServi
 
         if (matchingRows.All(r => string.IsNullOrWhiteSpace(r.RecyclabilityRating)))
         {
-            await FindAndAddErrorAsync(matchingRows[0], storeKey, warningRows, ErrorCode.LargeProducerRecyclabilityMissing, blobName);
+            foreach (var matchingRow in matchingRows.TakeWhile(_ => remainingWarningCountToProcess > 0))
+            {
+                await FindAndAddErrorAsync(matchingRow, storeKey, warningRows, ErrorCode.LargeProducerRecyclabilityMissing, blobName);
+                remainingWarningCountToProcess = await _issueCountService.GetRemainingIssueCapacityAsync(storeKey);
+            }
         }
     }
 }


### PR DESCRIPTION
- Ensures the new grouped validators identify all failing rows
- Altered the tests to cater for this
- Simplified the PartialRecyclabilityRatingSubmissionGroupedValidator to stop it enumerating the same lookup 3 times