### PR TITLE
chore(ELSP-332): remove DEV11 pipeline references

### DIFF
--- a/pipelines/deployment-pipeline.yaml
+++ b/pipelines/deployment-pipeline.yaml
@@ -18,7 +18,6 @@ parameters:
     - DEV7
     - DEV8
     - DEV9
-    - DEV11
     - DEV12
     - DEV13
     - DEV14

--- a/pipelines/vars/DEV11-development.yaml
+++ b/pipelines/vars/DEV11-development.yaml
@@ -1,6 +1,0 @@
-variables:
-  azureSubscription: 'AZD-RWD-DEV11'
-  docker.imageName: 'producervalidation'
-  acr.azureContainerRegistryName: 'devrwdinfac1401'
-  acr.repositoryName: 'producervalidationrepository'
-  serviceName: 'DEVRWDWEBFAB402'


### PR DESCRIPTION
Removes decommissioned **DEV11** references from the build pipeline (vars file(s), env value-list entries ).

Scope: pipeline definitions only. Ticket: ELSP-332